### PR TITLE
Calculate hash of native dll if zipped

### DIFF
--- a/Fody/NativeResources.cs
+++ b/Fody/NativeResources.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text.RegularExpressions;
 using Mono.Cecil;
@@ -21,7 +23,20 @@ partial class ModuleWeaver
 
             if (processedNameMatch.IsMatch(resource.Name))
             {
-                checksums.Add(resource.Name, CalculateChecksum(resource.GetResourceStream()));
+                using (Stream stream = resource.GetResourceStream())
+                {
+                    if (resource.Name.EndsWith(".zip"))
+                    {
+                        using (var compressStream = new DeflateStream(stream, CompressionMode.Decompress))
+                        {
+                            checksums.Add(resource.Name, CalculateChecksum(compressStream));
+                        }
+                    }
+                    else
+                    {
+                        checksums.Add(resource.Name, CalculateChecksum(stream));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
If you add a native dll, the hash is calculated on the zipped file, these leads to always replacing the dll. If the process is already running this follows with an `System.UnauthorizedAccessException` because it can't delete the dll. 
This fix adds the hash of the unzipped dll, which doesn't lead to that behaviour.
