### PR TITLE
Introduces LoadExistingAssemblyFromDisk option

### DIFF
--- a/Fody/AssemblyLoaderImporter.cs
+++ b/Fody/AssemblyLoaderImporter.cs
@@ -21,6 +21,7 @@ partial class ModuleWeaver
     FieldDefinition preload32ListField;
     FieldDefinition preload64ListField;
     FieldDefinition checksumsField;
+    FieldDefinition loadExistingAssemblyFromDiskField;
 
     void ImportAssemblyLoader(bool createTemporaryAssemblies)
     {
@@ -86,6 +87,8 @@ partial class ModuleWeaver
                 preload64ListField = newField;
             if (field.Name == "checksums")
                 checksumsField = newField;
+            if (field.Name == "loadExistingAssemblyFromDisk")
+                loadExistingAssemblyFromDiskField = newField;
         }
     }
 

--- a/Fody/AssemblyLoadingConfigurator.cs
+++ b/Fody/AssemblyLoadingConfigurator.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+partial class ModuleWeaver
+{
+    void SetBoolean(FieldDefinition field, bool value)
+    {
+        var retIndex = loaderCctor.Body.Instructions.Count - 1;
+        loaderCctor.Body.Instructions.InsertBefore(retIndex, new[] {
+            value ? Instruction.Create(OpCodes.Ldc_I4_1) : Instruction.Create(OpCodes.Ldc_I4_0),
+            Instruction.Create(OpCodes.Stsfld, field),
+        });
+    }
+}

--- a/Fody/Configuration.cs
+++ b/Fody/Configuration.cs
@@ -12,6 +12,7 @@ public class Configuration
         IncludeDebugSymbols = true;
         DisableCompression = false;
         CreateTemporaryAssemblies = false;
+        LoadExistingAssemblyFromDisk = true;
         IncludeAssemblies = new List<string>();
         ExcludeAssemblies = new List<string>();
         Unmanaged32Assemblies = new List<string>();
@@ -31,6 +32,7 @@ public class Configuration
         ReadBool(config, "IncludeDebugSymbols", b => IncludeDebugSymbols = b);
         ReadBool(config, "DisableCompression", b => DisableCompression = b);
         ReadBool(config, "CreateTemporaryAssemblies", b => CreateTemporaryAssemblies = b);
+        ReadBool(config, "LoadExistingAssemblyFromDisk", b => LoadExistingAssemblyFromDisk = b);
 
         ReadList(config, "ExcludeAssemblies", ExcludeAssemblies);
         ReadList(config, "IncludeAssemblies", IncludeAssemblies);
@@ -48,6 +50,7 @@ public class Configuration
     public bool IncludeDebugSymbols { get; private set; }
     public bool DisableCompression { get; private set; }
     public bool CreateTemporaryAssemblies { get; private set; }
+    public bool LoadExistingAssemblyFromDisk { get; private set; }
     public List<string> IncludeAssemblies { get; private set; }
     public List<string> ExcludeAssemblies { get; private set; }
     public List<string> Unmanaged32Assemblies { get; private set; }

--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -70,6 +70,7 @@
       <Link>template\ILTemplateWithUnmanagedHandler.cs</Link>
     </EmbeddedResource>
     <Compile Include="AssemblyLoaderImporter.cs" />
+    <Compile Include="AssemblyLoadingConfigurator.cs" />
     <Compile Include="Checksums.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="Extensions.cs" />

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -37,5 +37,6 @@ public partial class ModuleWeaver
 
         AddChecksumsToTemplate();
         BuildUpNameDictionary(config.CreateTemporaryAssemblies, config.PreloadOrder);
+        SetBoolean(loadExistingAssemblyFromDiskField, config.LoadExistingAssemblyFromDisk);
     }
 }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Embedded assemblies are compressed by default, and uncompressed when they are lo
 *Defaults to `false`*
 
     <Costura DisableCompression='false' />
+	
+### DisableCompression
+
+When an assembly which is embedded is present on the disk it is loaded by default. You can turn disk assembly loading off with this option.
+
+*Defaults to `true`*
+
+    <Costura LoadExistingAssemblyFromDisk='false' />	
     
 ### ExcludeAssemblies
 

--- a/Template/ILTemplate.cs
+++ b/Template/ILTemplate.cs
@@ -9,6 +9,8 @@ static class ILTemplate
     static readonly Dictionary<string, string> assemblyNames = new Dictionary<string, string>();
     static readonly Dictionary<string, string> symbolNames = new Dictionary<string, string>();
 
+    static readonly bool loadExistingAssemblyFromDisk;
+
     public static void Attach()
     {
         var currentDomain = AppDomain.CurrentDomain;
@@ -24,10 +26,14 @@ static class ILTemplate
 
         var requestedAssemblyName = new AssemblyName(args.Name);
 
-        var assembly = Common.ReadExistingAssembly(requestedAssemblyName);
-        if (assembly != null)
+        Assembly assembly;
+        if (loadExistingAssemblyFromDisk)
         {
-            return assembly;
+            assembly = Common.ReadExistingAssembly(requestedAssemblyName);
+            if (assembly != null)
+            {
+                return assembly;
+            }
         }
 
         var name = requestedAssemblyName.Name.ToLowerInvariant();

--- a/Template/ILTemplateWithTempAssembly.cs
+++ b/Template/ILTemplateWithTempAssembly.cs
@@ -15,6 +15,8 @@ static class ILTemplateWithTempAssembly
 
     static readonly Dictionary<string, string> checksums = new Dictionary<string, string>();
 
+    static readonly bool loadExistingAssemblyFromDisk;
+
     public static void Attach()
     {
         //Create a unique Temp directory for the application path.
@@ -42,10 +44,14 @@ static class ILTemplateWithTempAssembly
 
         var requestedAssemblyName = new AssemblyName(args.Name);
 
-        var assembly = Common.ReadExistingAssembly(requestedAssemblyName);
-        if (assembly != null)
+        Assembly assembly;
+        if (loadExistingAssemblyFromDisk)
         {
-            return assembly;
+            assembly = Common.ReadExistingAssembly(requestedAssemblyName);
+            if (assembly != null)
+            {
+                return assembly;
+            }
         }
 
         var name = requestedAssemblyName.Name.ToLowerInvariant();

--- a/Template/ILTemplateWithUnmanagedHandler.cs
+++ b/Template/ILTemplateWithUnmanagedHandler.cs
@@ -17,6 +17,8 @@ static class ILTemplateWithUnmanagedHandler
 
     static readonly Dictionary<string, string> checksums = new Dictionary<string, string>();
 
+    static readonly bool loadExistingAssemblyFromDisk;
+
     public static void Attach()
     {
         //Create a unique Temp directory for the application path.
@@ -41,10 +43,14 @@ static class ILTemplateWithUnmanagedHandler
 
         var requestedAssemblyName = new AssemblyName(args.Name);
 
-        var assembly = Common.ReadExistingAssembly(requestedAssemblyName);
-        if (assembly != null)
+        Assembly assembly;
+        if (loadExistingAssemblyFromDisk)
         {
-            return assembly;
+            assembly = Common.ReadExistingAssembly(requestedAssemblyName);
+            if (assembly != null)
+            {
+                return assembly;
+            }
         }
 
         var name = requestedAssemblyName.Name.ToLowerInvariant();


### PR DESCRIPTION
Introduces LoadExistingAssemblyFromDisk option which allows to disable assembly loading from disk. The behavior is preserved by setting it to LoadExistingAssemblyFromDisk="true" by default.

I hope I got this right. Total Mono.Cecil newbie
