### PR TITLE
#64 Fixed issue with unwanted double loading of assemblies

### DIFF
--- a/Fody/AssemblyLoaderImporter.cs
+++ b/Fody/AssemblyLoaderImporter.cs
@@ -48,7 +48,9 @@ partial class ModuleWeaver
         targetType.CustomAttributes.Add(new CustomAttribute(compilerGeneratedAttributeCtor));
         ModuleDefinition.Types.Add(targetType);
         CopyFields(sourceType);
+
         CopyMethod(sourceType.Methods.First(x => x.Name == "ResolveAssembly"));
+        CopyMethod(sourceType.Methods.First(x => x.Name == "OnAssemblyResolve"));
 
         loaderCctor = CopyMethod(sourceType.Methods.First(x => x.IsConstructor && x.IsStatic));
         attachMethod = CopyMethod(sourceType.Methods.First(x => x.Name == "Attach"));

--- a/Template/Common.cs
+++ b/Template/Common.cs
@@ -70,7 +70,7 @@ static class Common
         }
     }
 
-    public static Assembly ReadExistingAssembly(string assemblyName)
+    public static Assembly ReadExistingAssemblyByString(string assemblyName)
     {
         var currentDomain = AppDomain.CurrentDomain;
         var assemblies = currentDomain.GetAssemblies();
@@ -88,7 +88,7 @@ static class Common
         return null;
     }
 
-    public static Assembly ReadExistingAssembly(AssemblyName assemblyName)
+    public static Assembly ReadExistingAssemblyByAssemblyName(AssemblyName assemblyName)
     {
         var currentDomain = AppDomain.CurrentDomain;
         var assemblies = currentDomain.GetAssemblies();
@@ -136,7 +136,7 @@ static class Common
 
     public static Assembly ReadFromEmbeddedResources(Dictionary<string, string> assemblyNames, Dictionary<string, string> symbolNames, string name)
     {
-        var existingAssembly = ReadExistingAssembly(name);
+        var existingAssembly = ReadExistingAssemblyByString(name);
         if (existingAssembly != null)
         {
             return existingAssembly;

--- a/Template/ILTemplate.cs
+++ b/Template/ILTemplate.cs
@@ -12,10 +12,10 @@ static class ILTemplate
     public static void Attach()
     {
         var currentDomain = AppDomain.CurrentDomain;
-        currentDomain.AssemblyResolve += ResolveAssembly;
+        currentDomain.AssemblyResolve += OnAssemblyResolve;
     }
 
-    public static Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+    public static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
     {
         return ResolveAssembly(args.Name);
     }
@@ -29,7 +29,7 @@ static class ILTemplate
 
         var requestedAssemblyName = new AssemblyName(assemblyName);
 
-        var assembly = Common.ReadExistingAssembly(requestedAssemblyName);
+        var assembly = Common.ReadExistingAssemblyByAssemblyName(requestedAssemblyName);
         if (assembly != null)
         {
             return assembly;

--- a/Template/ILTemplateWithTempAssembly.cs
+++ b/Template/ILTemplateWithTempAssembly.cs
@@ -30,10 +30,10 @@ static class ILTemplateWithTempAssembly
         Common.PreloadUnmanagedLibraries(md5Hash, tempBasePath, libList, checksums);
 
         var currentDomain = AppDomain.CurrentDomain;
-        currentDomain.AssemblyResolve += ResolveAssembly;
+        currentDomain.AssemblyResolve += OnAssemblyResolve;
     }
 
-    public static Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+    public static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
     {
         return ResolveAssembly(args.Name);
     }
@@ -47,7 +47,7 @@ static class ILTemplateWithTempAssembly
 
         var requestedAssemblyName = new AssemblyName(assemblyName);
 
-        var assembly = Common.ReadExistingAssembly(requestedAssemblyName);
+        var assembly = Common.ReadExistingAssemblyByAssemblyName(requestedAssemblyName);
         if (assembly != null)
         {
             return assembly;

--- a/Template/ILTemplateWithUnmanagedHandler.cs
+++ b/Template/ILTemplateWithUnmanagedHandler.cs
@@ -29,10 +29,10 @@ static class ILTemplateWithUnmanagedHandler
         Common.PreloadUnmanagedLibraries(md5Hash, tempBasePath, unmanagedAssemblies, checksums);
 
         var currentDomain = AppDomain.CurrentDomain;
-        currentDomain.AssemblyResolve += ResolveAssembly;
+        currentDomain.AssemblyResolve += OnAssemblyResolve;
     }
 
-    public static Assembly ResolveAssembly(object sender, ResolveEventArgs args)
+    public static Assembly OnAssemblyResolve(object sender, ResolveEventArgs args)
     {
         return ResolveAssembly(args.Name);
     }
@@ -46,7 +46,7 @@ static class ILTemplateWithUnmanagedHandler
 
         var requestedAssemblyName = new AssemblyName(assemblyName);
 
-        var assembly = Common.ReadExistingAssembly(requestedAssemblyName);
+        var assembly = Common.ReadExistingAssemblyByAssemblyName(requestedAssemblyName);
         if (assembly != null)
         {
             return assembly;


### PR DESCRIPTION
Several new methods to read existing assemblies were added. The ReadFromEmbeddedResources now also checks whether an assembly is already loaded (and loading can thus be skipped). Also modified the ResolveAssembly methods so they can be used without EventArgs.
