### PR TITLE
Fix issue #74

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -2,5 +2,5 @@
 
 [assembly: AssemblyTitle("Costura")]
 [assembly: AssemblyProduct("Costura")]
-[assembly: AssemblyVersion("1.3.2")]
-[assembly: AssemblyFileVersion("1.3.2")]
+[assembly: AssemblyVersion("1.3.1")]
+[assembly: AssemblyFileVersion("1.3.1")]

--- a/Template/ILTemplate.cs
+++ b/Template/ILTemplate.cs
@@ -39,18 +39,24 @@ static class ILTemplate
 
             // We should get here only when we need to load a dependency of a dll we have embedded. If such dependency
             // it's not already loaded ("Common.ReadExistingAssembly" fails), and it's not in the same path of our application
-            // we let Fusion try to load it. We have to do this because "Common.ReadFromEmbeddedResources" uses Assembly.LoadFile
-            // that doesn't automatically load the dependencies.
-            // From: http://blogs.msdn.com/b/suzcook/archive/2003/09/19/loadfile-vs-loadfrom.aspx
+            // we let Fusion try to load it. We have to do this because "Common.ReadFromEmbeddedResources" uses Assembly.Load(byte[])
+            // that load the assembly in the "neither context".
+            // From: http://blogs.msdn.com/b/suzcook/archive/2003/05/29/choosing-a-binding-context.aspx
             //
-            // " LoadFile() has a catch. Since it doesn't use a binding context, its dependencies aren't automatically 
-            // " found in its directory. If they aren't available in the Load context, you would have to subscribe to the 
-            // " AssemblyResolve event in order to bind to them."
+            // "If the user generated or found the assembly instead of Fusion, it's in neither context. 
+            // This applies to assemblies loaded by Assembly.Load(byte[]) and Reflection Emit assemblies (
+            // that haven't been loaded from disk). Assembly.LoadFile() assemblies are also generally loaded into 
+            // this context, even though a path is given (because it doesn't go through Fusion)."
             //
+            // If Fusion can't find the dependencies of the just loaded assembly in the GAC (for example a retargetable library 
+            // like System.Core 2.0.0.5 used by PCL libraries) another AssemblyResolv event will be fired and we'll get here.
             // If the dependencies is not found we won't get any StackOverflowException (caused by the call to Assembly.Load
-            // that recursively fire another AssemblyResolve event) because we have already added the requestedAssemblyName
+            // that recursively fire another AssemblyResolve event because we have already added the requestedAssemblyName
             // to the nullCache and we'll just skip it next time it's "asked".
-            assembly = Assembly.Load(requestedAssemblyName);
+            if (requestedAssemblyName.Flags == AssemblyNameFlags.Retargetable)
+            {
+                assembly = Assembly.Load(requestedAssemblyName);
+            }
         }
         return assembly;
     }


### PR DESCRIPTION
The problem in issue #74 is due to the fact that "Assembly.Load(Byte[[)" loads assembly in "neither" context" and so Fusion can't find the dependencies of such an assembly and fires another AssemblyResolve event. If such dependencies aren't already loaded or embedded in the executable, Costura's handler can't find them and we'll get an FileNotFoundException. That exception can simply be fixed by giving Fusion a try to load such dependencies with Assembly.Load.
