### PR TITLE
Set Mutextimeout to 60 seconds to fix timeouts on very slow systems

### DIFF
--- a/Template/Common.cs
+++ b/Template/Common.cs
@@ -207,7 +207,7 @@ static class Common
             {
                 try
                 {
-                    hasHandle = mutex.WaitOne(5000, false);
+                    hasHandle = mutex.WaitOne(60000, false);
                     if (hasHandle == false)
                         throw new TimeoutException("Timeout waiting for exclusive access");
                 }


### PR DESCRIPTION
On very slow systems, with low memory and slow harddisk, accessed from multiple clients via RDP the mutex timeout is to low, timeouts and crashes. 
So I set this up to 60 seconds. 
If you think this is too high, maybe it is better to make it configurable via the xml.
