### PR TITLE
Preventing re-entrant calls to AssemblyResolve (Fixed #82)

### DIFF
--- a/Template/ILTemplate.cs
+++ b/Template/ILTemplate.cs
@@ -12,7 +12,21 @@ static class ILTemplate
     public static void Attach()
     {
         var currentDomain = AppDomain.CurrentDomain;
-        currentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
+	    bool reenterant = false;
+	    currentDomain.AssemblyResolve += (s, e) =>
+	    {
+		    if (reenterant)
+			    return null;
+		    try
+		    {
+			    reenterant = true;
+			    return ResolveAssembly(e.Name);
+		    }
+		    finally
+		    {
+			    reenterant = false;
+		    }
+	    };
     }
 
     public static Assembly ResolveAssembly(string assemblyName)

--- a/Template/ILTemplateWithTempAssembly.cs
+++ b/Template/ILTemplateWithTempAssembly.cs
@@ -30,7 +30,21 @@ static class ILTemplateWithTempAssembly
         Common.PreloadUnmanagedLibraries(md5Hash, tempBasePath, libList, checksums);
 
         var currentDomain = AppDomain.CurrentDomain;
-        currentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
+		bool reenterant = false;
+		currentDomain.AssemblyResolve += (s, e) =>
+		{
+			if (reenterant)
+				return null;
+			try
+			{
+				reenterant = true;
+				return ResolveAssembly(e.Name);
+			}
+			finally
+			{
+				reenterant = false;
+			}
+		};
     }
 
     public static Assembly ResolveAssembly(string assemblyName)

--- a/Template/ILTemplateWithUnmanagedHandler.cs
+++ b/Template/ILTemplateWithUnmanagedHandler.cs
@@ -29,7 +29,21 @@ static class ILTemplateWithUnmanagedHandler
         Common.PreloadUnmanagedLibraries(md5Hash, tempBasePath, unmanagedAssemblies, checksums);
 
         var currentDomain = AppDomain.CurrentDomain;
-        currentDomain.AssemblyResolve += (s, e) => ResolveAssembly(e.Name);
+		bool reenterant = false;
+		currentDomain.AssemblyResolve += (s, e) =>
+		{
+			if (reenterant)
+				return null;
+			try
+			{
+				reenterant = true;
+				return ResolveAssembly(e.Name);
+			}
+			finally
+			{
+				reenterant = false;
+			}
+		};
     }
 
     public static Assembly ResolveAssembly(string assemblyName)


### PR DESCRIPTION
The idea is to simply detect that we have are re entrant and exit (we can't handle that scenario at all).
Note that based on the code, (use of Dictionary), I'm assuming that there is no need to handle concurrency, so I choose a simple model for that.
