### PR TITLE
Fixes for NET45

### DIFF
--- a/Fody/ResourceEmbedder.cs
+++ b/Fody/ResourceEmbedder.cs
@@ -23,6 +23,8 @@ partial class ModuleWeaver : IDisposable
             Directory.CreateDirectory(cachePath);
         }
 
+        var assembliesAdded = false;
+
         var onlyBinaries = ReferenceCopyLocalPaths.Where(x => x.EndsWith(".dll") || x.EndsWith(".exe"));
 
         foreach (var dependency in GetFilteredReferences(onlyBinaries, config))
@@ -42,6 +44,8 @@ partial class ModuleWeaver : IDisposable
             }
 
             resourceName = Embed("costura.", fullPath, !config.DisableCompression);
+            assembliesAdded = true;
+
             if (config.CreateTemporaryAssemblies)
             {
                 checksums.Add(resourceName, CalculateChecksum(fullPath));
@@ -54,6 +58,8 @@ partial class ModuleWeaver : IDisposable
             if (File.Exists(pdbFullPath))
             {
                 resourceName = Embed("costura.", pdbFullPath, !config.DisableCompression);
+                assembliesAdded = true;
+
                 if (config.CreateTemporaryAssemblies)
                 {
                     checksums.Add(resourceName, CalculateChecksum(pdbFullPath));
@@ -83,6 +89,8 @@ partial class ModuleWeaver : IDisposable
 
             var fullPath = Path.GetFullPath(dependency);
             var resourceName = Embed(prefix, fullPath, config.DisableCompression);
+            assembliesAdded = true;
+
             checksums.Add(resourceName, CalculateChecksum(fullPath));
             if (!config.IncludeDebugSymbols)
             {
@@ -92,8 +100,15 @@ partial class ModuleWeaver : IDisposable
             if (File.Exists(pdbFullPath))
             {
                 resourceName = Embed(prefix, pdbFullPath, config.DisableCompression);
+                assembliesAdded = true;
+
                 checksums.Add(resourceName, CalculateChecksum(pdbFullPath));
             }
+        }
+
+        if (!assembliesAdded)
+        {
+            LogInfo("No assemblies were embedded");
         }
     }
 

--- a/Tests/InMemoryTests.TemplateHasCorrectSymbols.approved.txt
+++ b/Tests/InMemoryTests.TemplateHasCorrectSymbols.approved.txt
@@ -188,9 +188,9 @@
     .maxstack  2
     .locals init ([0] bool ,
              [1] string V_1)
-    .line 98,98 : 5,6 'AssemblyToProcess\\bin\\Debug\\Common.cs'
+    .line 96,96 : 5,6 'AssemblyToProcess\\bin\\Debug\\Common.cs'
     IL_0000:  nop
-    .line 99,99 : 9,29 ''
+    .line 97,97 : 9,29 ''
     IL_0001:  ldarg.0
     IL_0002:  ldnull
     IL_0003:  ceq
@@ -198,16 +198,16 @@
     .line 16707566,16707566 : 0,0 ''
     IL_0006:  ldloc.0
     IL_0007:  brfalse.s  IL_0011
-    .line 100,100 : 13,23 ''
+    .line 98,98 : 13,23 ''
     IL_0009:  ldstr      ""
     IL_000e:  stloc.1
     IL_000f:  br.s       IL_001a
-    .line 102,102 : 9,29 ''
+    .line 100,100 : 9,29 ''
     IL_0011:  ldarg.0
     IL_0012:  callvirt   instance string [mscorlib]System.Globalization.CultureInfo::get_Name()
     IL_0017:  stloc.1
     IL_0018:  br.s       IL_001a
-    .line 103,103 : 5,6 ''
+    .line 101,101 : 5,6 ''
     IL_001a:  ldloc.1
     IL_001b:  ret
   } // end of method AssemblyLoader::CultureToString
@@ -244,36 +244,36 @@
              [5] class [mscorlib]System.Reflection.AssemblyName currentName,
              [6] bool V_6,
              [7] class [mscorlib]System.Reflection.Assembly V_7)
-    .line 80,80 : 5,6 ''
+    .line 78,78 : 5,6 ''
     IL_0000:  nop
-    .line 81,81 : 9,53 ''
+    .line 79,79 : 9,53 ''
     IL_0001:  call       class [mscorlib]System.AppDomain [mscorlib]System.AppDomain::get_CurrentDomain()
     IL_0006:  stloc.0
-    .line 82,82 : 9,56 ''
+    .line 80,80 : 9,56 ''
     IL_0007:  ldloc.0
     IL_0008:  callvirt   instance class [mscorlib]System.Reflection.Assembly[] [mscorlib]System.AppDomain::GetAssemblies()
     IL_000d:  stloc.1
-    .line 83,83 : 9,16 ''
+    .line 81,81 : 9,16 ''
     IL_000e:  nop
-    .line 83,83 : 34,44 ''
+    .line 81,81 : 34,44 ''
     IL_000f:  ldloc.1
     IL_0010:  stloc.2
     IL_0011:  ldc.i4.0
     IL_0012:  stloc.3
     .line 16707566,16707566 : 0,0 ''
     IL_0013:  br.s       IL_0086
-    .line 83,83 : 18,30 ''
+    .line 81,81 : 18,30 ''
     IL_0015:  ldloc.2
     IL_0016:  ldloc.3
     IL_0017:  ldelem.ref
     IL_0018:  stloc.s    'assembly'
-    .line 84,84 : 9,10 ''
+    .line 82,82 : 9,10 ''
     IL_001a:  nop
-    .line 85,85 : 13,50 ''
+    .line 83,83 : 13,50 ''
     IL_001b:  ldloc.s    'assembly'
     IL_001d:  callvirt   instance class [mscorlib]System.Reflection.AssemblyName [mscorlib]System.Reflection.Assembly::GetName()
     IL_0022:  stloc.s    currentName
-    .line 86,87 : 13,153 ''
+    .line 84,85 : 13,153 ''
     IL_0024:  ldloc.s    currentName
     IL_0026:  callvirt   instance string [mscorlib]System.Reflection.AssemblyName::get_Name()
     IL_002b:  ldarg.0
@@ -299,9 +299,9 @@
     .line 16707566,16707566 : 0,0 ''
     IL_005b:  ldloc.s    V_6
     IL_005d:  brfalse.s  IL_0081
-    .line 88,88 : 13,14 ''
+    .line 86,86 : 13,14 ''
     IL_005f:  nop
-    .line 89,89 : 17,102 ''
+    .line 87,87 : 17,102 ''
     IL_0060:  ldstr      "Assembly '{0}' already loaded, returning existing "
     + "assembly"
     IL_0065:  ldc.i4.1
@@ -314,28 +314,28 @@
     IL_0075:  call       void Costura.AssemblyLoader::Log(string,
                                                           object[])
     IL_007a:  nop
-    .line 91,91 : 17,33 ''
+    .line 89,89 : 17,33 ''
     IL_007b:  ldloc.s    'assembly'
     IL_007d:  stloc.s    V_7
     IL_007f:  br.s       IL_0091
-    .line 93,93 : 9,10 ''
+    .line 91,91 : 9,10 ''
     IL_0081:  nop
     .line 16707566,16707566 : 0,0 ''
     IL_0082:  ldloc.3
     IL_0083:  ldc.i4.1
     IL_0084:  add
     IL_0085:  stloc.3
-    .line 83,83 : 31,33 ''
+    .line 81,81 : 31,33 ''
     IL_0086:  ldloc.3
     IL_0087:  ldloc.2
     IL_0088:  ldlen
     IL_0089:  conv.i4
     IL_008a:  blt.s      IL_0015
-    .line 94,94 : 9,21 ''
+    .line 92,92 : 9,21 ''
     IL_008c:  ldnull
     IL_008d:  stloc.s    V_7
     IL_008f:  br.s       IL_0091
-    .line 95,95 : 5,6 ''
+    .line 93,93 : 5,6 ''
     IL_0091:  ldloc.s    V_7
     IL_0093:  ret
   } // end of method AssemblyLoader::ReadExistingAssembly
@@ -354,14 +354,14 @@
              [6] bool V_6,
              [7] bool V_7,
              [8] bool V_8)
-    .line 106,106 : 5,6 ''
+    .line 104,104 : 5,6 ''
     IL_0000:  nop
-    .line 107,107 : 9,66 ''
+    .line 105,105 : 9,66 ''
     IL_0001:  ldarg.1
     IL_0002:  callvirt   instance string [mscorlib]System.Reflection.AssemblyName::get_Name()
     IL_0007:  callvirt   instance string [mscorlib]System.String::ToLowerInvariant()
     IL_000c:  stloc.0
-    .line 109,109 : 9,120 ''
+    .line 107,107 : 9,120 ''
     IL_000d:  ldarg.1
     IL_000e:  callvirt   instance class [mscorlib]System.Globalization.CultureInfo [mscorlib]System.Reflection.AssemblyName::get_CultureInfo()
     IL_0013:  brfalse.s  IL_002a
@@ -377,7 +377,7 @@
     .line 16707566,16707566 : 0,0 ''
     IL_002c:  ldloc.3
     IL_002d:  brfalse.s  IL_0046
-    .line 110,110 : 13,91 ''
+    .line 108,108 : 13,91 ''
     IL_002f:  ldstr      "{0}.{1}"
     IL_0034:  ldarg.1
     IL_0035:  callvirt   instance class [mscorlib]System.Globalization.CultureInfo [mscorlib]System.Reflection.AssemblyName::get_CultureInfo()
@@ -387,7 +387,7 @@
                                                                 object,
                                                                 object)
     IL_0045:  stloc.0
-    .line 112,112 : 9,56 ''
+    .line 110,110 : 9,56 ''
     IL_0046:  call       int32 [mscorlib]System.IntPtr::get_Size()
     IL_004b:  ldc.i4.8
     IL_004c:  beq.s      IL_0055
@@ -395,7 +395,7 @@
     IL_0053:  br.s       IL_005a
     IL_0055:  ldstr      "64"
     IL_005a:  stloc.1
-    .line 113,113 : 9,92 ''
+    .line 111,111 : 9,92 ''
     IL_005b:  ldarg.0
     IL_005c:  ldloc.0
     IL_005d:  ldstr      ".dll"
@@ -404,41 +404,41 @@
     IL_0067:  call       string [mscorlib]System.IO.Path::Combine(string,
                                                                   string)
     IL_006c:  stloc.2
-    .line 114,114 : 9,47 ''
+    .line 112,112 : 9,47 ''
     IL_006d:  ldloc.2
     IL_006e:  call       bool [mscorlib]System.IO.File::Exists(string)
     IL_0073:  stloc.s    V_4
     .line 16707566,16707566 : 0,0 ''
     IL_0075:  ldloc.s    V_4
     IL_0077:  brfalse.s  IL_0084
-    .line 115,115 : 9,10 ''
+    .line 113,113 : 9,10 ''
     IL_0079:  nop
-    .line 116,116 : 13,60 ''
+    .line 114,114 : 13,60 ''
     IL_007a:  ldloc.2
     IL_007b:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::LoadFile(string)
     IL_0080:  stloc.s    V_5
     IL_0082:  br.s       IL_00fe
-    .line 118,118 : 9,82 ''
+    .line 116,116 : 9,82 ''
     IL_0084:  ldloc.2
     IL_0085:  ldstr      "exe"
     IL_008a:  call       string [mscorlib]System.IO.Path::ChangeExtension(string,
                                                                           string)
     IL_008f:  stloc.2
-    .line 119,119 : 9,47 ''
+    .line 117,117 : 9,47 ''
     IL_0090:  ldloc.2
     IL_0091:  call       bool [mscorlib]System.IO.File::Exists(string)
     IL_0096:  stloc.s    V_6
     .line 16707566,16707566 : 0,0 ''
     IL_0098:  ldloc.s    V_6
     IL_009a:  brfalse.s  IL_00a7
-    .line 120,120 : 9,10 ''
+    .line 118,118 : 9,10 ''
     IL_009c:  nop
-    .line 121,121 : 13,60 ''
+    .line 119,119 : 13,60 ''
     IL_009d:  ldloc.2
     IL_009e:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::LoadFile(string)
     IL_00a3:  stloc.s    V_5
     IL_00a5:  br.s       IL_00fe
-    .line 123,123 : 9,113 ''
+    .line 121,121 : 9,113 ''
     IL_00a7:  ldarg.0
     IL_00a8:  ldloc.1
     IL_00a9:  call       string [mscorlib]System.IO.Path::Combine(string,
@@ -450,45 +450,45 @@
     IL_00b9:  call       string [mscorlib]System.IO.Path::Combine(string,
                                                                   string)
     IL_00be:  stloc.2
-    .line 124,124 : 9,47 ''
+    .line 122,122 : 9,47 ''
     IL_00bf:  ldloc.2
     IL_00c0:  call       bool [mscorlib]System.IO.File::Exists(string)
     IL_00c5:  stloc.s    V_7
     .line 16707566,16707566 : 0,0 ''
     IL_00c7:  ldloc.s    V_7
     IL_00c9:  brfalse.s  IL_00d6
-    .line 125,125 : 9,10 ''
+    .line 123,123 : 9,10 ''
     IL_00cb:  nop
-    .line 126,126 : 13,60 ''
+    .line 124,124 : 13,60 ''
     IL_00cc:  ldloc.2
     IL_00cd:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::LoadFile(string)
     IL_00d2:  stloc.s    V_5
     IL_00d4:  br.s       IL_00fe
-    .line 128,128 : 9,82 ''
+    .line 126,126 : 9,82 ''
     IL_00d6:  ldloc.2
     IL_00d7:  ldstr      "exe"
     IL_00dc:  call       string [mscorlib]System.IO.Path::ChangeExtension(string,
                                                                           string)
     IL_00e1:  stloc.2
-    .line 129,129 : 9,47 ''
+    .line 127,127 : 9,47 ''
     IL_00e2:  ldloc.2
     IL_00e3:  call       bool [mscorlib]System.IO.File::Exists(string)
     IL_00e8:  stloc.s    V_8
     .line 16707566,16707566 : 0,0 ''
     IL_00ea:  ldloc.s    V_8
     IL_00ec:  brfalse.s  IL_00f9
-    .line 130,130 : 9,10 ''
+    .line 128,128 : 9,10 ''
     IL_00ee:  nop
-    .line 131,131 : 13,60 ''
+    .line 129,129 : 13,60 ''
     IL_00ef:  ldloc.2
     IL_00f0:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::LoadFile(string)
     IL_00f5:  stloc.s    V_5
     IL_00f7:  br.s       IL_00fe
-    .line 133,133 : 9,21 ''
+    .line 131,131 : 9,21 ''
     IL_00f9:  ldnull
     IL_00fa:  stloc.s    V_5
     IL_00fc:  br.s       IL_00fe
-    .line 134,134 : 5,6 ''
+    .line 132,132 : 5,6 ''
     IL_00fe:  ldloc.s    V_5
     IL_0100:  ret
   } // end of method AssemblyLoader::ReadFromDiskCache
@@ -553,12 +553,12 @@
              [3] class [System]System.IO.Compression.DeflateStream compressStream,
              [4] class [mscorlib]System.IO.MemoryStream memStream,
              [5] class [mscorlib]System.IO.Stream V_5)
-    .line 175,175 : 5,6 ''
+    .line 173,173 : 5,6 ''
     IL_0000:  nop
-    .line 176,176 : 9,65 ''
+    .line 174,174 : 9,65 ''
     IL_0001:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::GetExecutingAssembly()
     IL_0006:  stloc.0
-    .line 178,178 : 9,39 ''
+    .line 176,176 : 9,39 ''
     IL_0007:  ldarg.0
     IL_0008:  ldstr      ".zip"
     IL_000d:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
@@ -566,14 +566,14 @@
     .line 16707566,16707566 : 0,0 ''
     IL_0013:  ldloc.1
     IL_0014:  brfalse.s  IL_005e
-    .line 179,179 : 9,10 ''
+    .line 177,177 : 9,10 ''
     IL_0016:  nop
-    .line 180,180 : 20,86 ''
+    .line 178,178 : 20,86 ''
     IL_0017:  ldloc.0
     IL_0018:  ldarg.0
     IL_0019:  callvirt   instance class [mscorlib]System.IO.Stream [mscorlib]System.Reflection.Assembly::GetManifestResourceStream(string)
     IL_001e:  stloc.2
-    .line 181,181 : 20,94 ''
+    .line 179,179 : 20,94 ''
     .try
     {
       IL_001f:  ldloc.2
@@ -581,26 +581,26 @@
       IL_0021:  newobj     instance void [System]System.IO.Compression.DeflateStream::.ctor(class [mscorlib]System.IO.Stream,
                                                                                             valuetype [System]System.IO.Compression.CompressionMode)
       IL_0026:  stloc.3
-      .line 182,182 : 13,14 ''
+      .line 180,180 : 13,14 ''
       .try
       {
         IL_0027:  nop
-        .line 183,183 : 17,52 ''
+        .line 181,181 : 17,52 ''
         IL_0028:  newobj     instance void [mscorlib]System.IO.MemoryStream::.ctor()
         IL_002d:  stloc.s    memStream
-        .line 184,184 : 17,51 ''
+        .line 182,182 : 17,51 ''
         IL_002f:  ldloc.3
         IL_0030:  ldloc.s    memStream
         IL_0032:  call       void Costura.AssemblyLoader::CopyTo(class [mscorlib]System.IO.Stream,
                                                                  class [mscorlib]System.IO.Stream)
         IL_0037:  nop
-        .line 185,185 : 17,40 ''
+        .line 183,183 : 17,40 ''
         IL_0038:  ldloc.s    memStream
         IL_003a:  ldc.i4.0
         IL_003b:  conv.i8
         IL_003c:  callvirt   instance void [mscorlib]System.IO.Stream::set_Position(int64)
         IL_0041:  nop
-        .line 186,186 : 17,34 ''
+        .line 184,184 : 17,34 ''
         IL_0042:  ldloc.s    memStream
         IL_0044:  stloc.s    V_5
         IL_0046:  leave.s    IL_0069
@@ -625,14 +625,14 @@
       IL_0057:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_005c:  nop
       IL_005d:  endfinally
-      .line 190,190 : 9,70 ''
+      .line 188,188 : 9,70 ''
     }  // end handler
     IL_005e:  ldloc.0
     IL_005f:  ldarg.0
     IL_0060:  callvirt   instance class [mscorlib]System.IO.Stream [mscorlib]System.Reflection.Assembly::GetManifestResourceStream(string)
     IL_0065:  stloc.s    V_5
     IL_0067:  br.s       IL_0069
-    .line 191,191 : 5,6 ''
+    .line 189,189 : 5,6 ''
     IL_0069:  ldloc.s    V_5
     IL_006b:  ret
   } // end of method AssemblyLoader::LoadStream
@@ -645,9 +645,9 @@
     .locals init ([0] string 'value',
              [1] bool ,
              [2] class [mscorlib]System.IO.Stream V_2)
-    .line 166,166 : 5,6 ''
+    .line 164,164 : 5,6 ''
     IL_0000:  nop
-    .line 168,168 : 9,56 ''
+    .line 166,166 : 9,56 ''
     IL_0001:  ldarg.0
     IL_0002:  ldarg.1
     IL_0003:  ldloca.s   'value'
@@ -657,16 +657,16 @@
     .line 16707566,16707566 : 0,0 ''
     IL_000b:  ldloc.1
     IL_000c:  brfalse.s  IL_0017
-    .line 169,169 : 13,38 ''
+    .line 167,167 : 13,38 ''
     IL_000e:  ldloc.0
     IL_000f:  call       class [mscorlib]System.IO.Stream Costura.AssemblyLoader::LoadStream(string)
     IL_0014:  stloc.2
     IL_0015:  br.s       IL_001b
-    .line 171,171 : 9,21 ''
+    .line 169,169 : 9,21 ''
     IL_0017:  ldnull
     IL_0018:  stloc.2
     IL_0019:  br.s       IL_001b
-    .line 172,172 : 5,6 ''
+    .line 170,170 : 5,6 ''
     IL_001b:  ldloc.2
     IL_001c:  ret
   } // end of method AssemblyLoader::LoadStream
@@ -720,14 +720,14 @@
              [6] class [mscorlib]System.IO.Stream pdbStream,
              [7] bool V_7,
              [8] uint8[] pdbData)
-    .line 137,137 : 5,6 ''
+    .line 135,135 : 5,6 ''
     IL_0000:  nop
-    .line 138,138 : 9,66 ''
+    .line 136,136 : 9,66 ''
     IL_0001:  ldarg.2
     IL_0002:  callvirt   instance string [mscorlib]System.Reflection.AssemblyName::get_Name()
     IL_0007:  callvirt   instance string [mscorlib]System.String::ToLowerInvariant()
     IL_000c:  stloc.0
-    .line 140,140 : 9,120 ''
+    .line 138,138 : 9,120 ''
     IL_000d:  ldarg.2
     IL_000e:  callvirt   instance class [mscorlib]System.Globalization.CultureInfo [mscorlib]System.Reflection.AssemblyName::get_CultureInfo()
     IL_0013:  brfalse.s  IL_002a
@@ -743,7 +743,7 @@
     .line 16707566,16707566 : 0,0 ''
     IL_002c:  ldloc.2
     IL_002d:  brfalse.s  IL_0046
-    .line 141,141 : 13,91 ''
+    .line 139,139 : 13,91 ''
     IL_002f:  ldstr      "{0}.{1}"
     IL_0034:  ldarg.2
     IL_0035:  callvirt   instance class [mscorlib]System.Globalization.CultureInfo [mscorlib]System.Reflection.AssemblyName::get_CultureInfo()
@@ -753,17 +753,17 @@
                                                                 object,
                                                                 object)
     IL_0045:  stloc.0
-    .line 144,144 : 16,68 ''
+    .line 142,142 : 16,68 ''
     IL_0046:  ldarg.0
     IL_0047:  ldloc.0
     IL_0048:  call       class [mscorlib]System.IO.Stream Costura.AssemblyLoader::LoadStream(class [mscorlib]System.Collections.Generic.Dictionary`2<string,string>,
                                                                                              string)
     IL_004d:  stloc.3
-    .line 145,145 : 9,10 ''
+    .line 143,143 : 9,10 ''
     .try
     {
       IL_004e:  nop
-      .line 146,146 : 13,40 ''
+      .line 144,144 : 13,40 ''
       IL_004f:  ldloc.3
       IL_0050:  ldnull
       IL_0051:  ceq
@@ -771,17 +771,17 @@
       .line 16707566,16707566 : 0,0 ''
       IL_0055:  ldloc.s    V_4
       IL_0057:  brfalse.s  IL_005f
-      .line 147,147 : 13,14 ''
+      .line 145,145 : 13,14 ''
       IL_0059:  nop
-      .line 148,148 : 17,29 ''
+      .line 146,146 : 17,29 ''
       IL_005a:  ldnull
       IL_005b:  stloc.s    V_5
       IL_005d:  leave.s    IL_00b9
-      .line 150,150 : 13,55 ''
+      .line 148,148 : 13,55 ''
       IL_005f:  ldloc.3
       IL_0060:  call       uint8[] Costura.AssemblyLoader::ReadStream(class [mscorlib]System.IO.Stream)
       IL_0065:  stloc.1
-      .line 151,151 : 9,10 ''
+      .line 149,149 : 9,10 ''
       IL_0066:  nop
       IL_0067:  leave.s    IL_0074
       .line 16707566,16707566 : 0,0 ''
@@ -794,18 +794,18 @@
       IL_006d:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_0072:  nop
       IL_0073:  endfinally
-      .line 153,153 : 16,61 ''
+      .line 151,151 : 16,61 ''
     }  // end handler
     IL_0074:  ldarg.1
     IL_0075:  ldloc.0
     IL_0076:  call       class [mscorlib]System.IO.Stream Costura.AssemblyLoader::LoadStream(class [mscorlib]System.Collections.Generic.Dictionary`2<string,string>,
                                                                                              string)
     IL_007b:  stloc.s    pdbStream
-    .line 154,154 : 9,10 ''
+    .line 152,152 : 9,10 ''
     .try
     {
       IL_007d:  nop
-      .line 155,155 : 13,35 ''
+      .line 153,153 : 13,35 ''
       IL_007e:  ldloc.s    pdbStream
       IL_0080:  ldnull
       IL_0081:  cgt.un
@@ -813,20 +813,20 @@
       .line 16707566,16707566 : 0,0 ''
       IL_0085:  ldloc.s    V_7
       IL_0087:  brfalse.s  IL_009f
-      .line 156,156 : 13,14 ''
+      .line 154,154 : 13,14 ''
       IL_0089:  nop
-      .line 157,157 : 17,53 ''
+      .line 155,155 : 17,53 ''
       IL_008a:  ldloc.s    pdbStream
       IL_008c:  call       uint8[] Costura.AssemblyLoader::ReadStream(class [mscorlib]System.IO.Stream)
       IL_0091:  stloc.s    pdbData
-      .line 158,158 : 17,61 ''
+      .line 156,156 : 17,61 ''
       IL_0093:  ldloc.1
       IL_0094:  ldloc.s    pdbData
       IL_0096:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::Load(uint8[],
                                                                                                                  uint8[])
       IL_009b:  stloc.s    V_5
       IL_009d:  leave.s    IL_00b9
-      .line 160,160 : 9,10 ''
+      .line 158,158 : 9,10 ''
       IL_009f:  nop
       IL_00a0:  leave.s    IL_00af
       .line 16707566,16707566 : 0,0 ''
@@ -839,13 +839,13 @@
       IL_00a8:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_00ad:  nop
       IL_00ae:  endfinally
-      .line 162,162 : 9,44 ''
+      .line 160,160 : 9,44 ''
     }  // end handler
     IL_00af:  ldloc.1
     IL_00b0:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::Load(uint8[])
     IL_00b5:  stloc.s    V_5
     IL_00b7:  br.s       IL_00b9
-    .line 163,163 : 5,6 ''
+    .line 161,161 : 5,6 ''
     IL_00b9:  ldloc.s    V_5
     IL_00bb:  ret
   } // end of method AssemblyLoader::ReadFromEmbeddedResources
@@ -968,7 +968,7 @@
   .method private hidebysig static string 
           ResourceNameToPath(string lib) cil managed
   {
-    // Code size       131 (0x83)
+    // Code size       137 (0x89)
     .maxstack  4
     .locals init ([0] string bittyness,
              [1] string name,
@@ -976,9 +976,9 @@
              [3] bool V_3,
              [4] bool V_4,
              [5] string V_5)
-    .line 278,278 : 5,6 ''
+    .line 276,276 : 5,6 ''
     IL_0000:  nop
-    .line 279,279 : 9,56 ''
+    .line 277,277 : 9,56 ''
     IL_0001:  call       int32 [mscorlib]System.IntPtr::get_Size()
     IL_0006:  ldc.i4.8
     IL_0007:  beq.s      IL_0010
@@ -986,10 +986,10 @@
     IL_000e:  br.s       IL_0015
     IL_0010:  ldstr      "64"
     IL_0015:  stloc.0
-    .line 281,281 : 9,27 ''
+    .line 279,279 : 9,24 ''
     IL_0016:  ldarg.0
     IL_0017:  stloc.1
-    .line 283,283 : 9,70 ''
+    .line 281,281 : 9,70 ''
     IL_0018:  ldarg.0
     IL_0019:  ldstr      "costura"
     IL_001e:  ldloc.0
@@ -1001,59 +1001,71 @@
     IL_002e:  stloc.2
     .line 16707566,16707566 : 0,0 ''
     IL_002f:  ldloc.2
-    IL_0030:  brfalse.s  IL_0043
-    .line 284,284 : 13,63 ''
-    IL_0032:  ldloc.0
-    IL_0033:  ldarg.0
-    IL_0034:  ldc.i4.s   10
-    IL_0036:  callvirt   instance string [mscorlib]System.String::Substring(int32)
-    IL_003b:  call       string [mscorlib]System.IO.Path::Combine(string,
+    IL_0030:  brfalse.s  IL_0045
+    .line 282,282 : 9,10 ''
+    IL_0032:  nop
+    .line 283,283 : 13,63 ''
+    IL_0033:  ldloc.0
+    IL_0034:  ldarg.0
+    IL_0035:  ldc.i4.s   10
+    IL_0037:  callvirt   instance string [mscorlib]System.String::Substring(int32)
+    IL_003c:  call       string [mscorlib]System.IO.Path::Combine(string,
                                                                   string)
-    IL_0040:  stloc.1
-    IL_0041:  br.s       IL_005a
+    IL_0041:  stloc.1
+    .line 284,284 : 9,10 ''
+    IL_0042:  nop
+    IL_0043:  br.s       IL_005e
     .line 285,285 : 14,45 ''
-    IL_0043:  ldarg.0
-    IL_0044:  ldstr      "costura."
-    IL_0049:  callvirt   instance bool [mscorlib]System.String::StartsWith(string)
-    IL_004e:  stloc.3
+    IL_0045:  ldarg.0
+    IL_0046:  ldstr      "costura."
+    IL_004b:  callvirt   instance bool [mscorlib]System.String::StartsWith(string)
+    IL_0050:  stloc.3
     .line 16707566,16707566 : 0,0 ''
-    IL_004f:  ldloc.3
-    IL_0050:  brfalse.s  IL_005a
-    .line 286,286 : 13,37 ''
-    IL_0052:  ldarg.0
-    IL_0053:  ldc.i4.8
-    IL_0054:  callvirt   instance string [mscorlib]System.String::Substring(int32)
-    IL_0059:  stloc.1
-    .line 288,288 : 9,35 ''
-    IL_005a:  ldloc.1
-    IL_005b:  ldstr      ".zip"
-    IL_0060:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
-    IL_0065:  stloc.s    V_4
+    IL_0051:  ldloc.3
+    IL_0052:  brfalse.s  IL_005e
+    .line 286,286 : 9,10 ''
+    IL_0054:  nop
+    .line 287,287 : 13,37 ''
+    IL_0055:  ldarg.0
+    IL_0056:  ldc.i4.8
+    IL_0057:  callvirt   instance string [mscorlib]System.String::Substring(int32)
+    IL_005c:  stloc.1
+    .line 288,288 : 9,10 ''
+    IL_005d:  nop
+    .line 290,290 : 9,35 ''
+    IL_005e:  ldloc.1
+    IL_005f:  ldstr      ".zip"
+    IL_0064:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
+    IL_0069:  stloc.s    V_4
     .line 16707566,16707566 : 0,0 ''
-    IL_0067:  ldloc.s    V_4
-    IL_0069:  brfalse.s  IL_007b
-    .line 289,289 : 13,55 ''
-    IL_006b:  ldloc.1
-    IL_006c:  ldc.i4.0
-    IL_006d:  ldloc.1
-    IL_006e:  callvirt   instance int32 [mscorlib]System.String::get_Length()
-    IL_0073:  ldc.i4.4
-    IL_0074:  sub
-    IL_0075:  callvirt   instance string [mscorlib]System.String::Substring(int32,
+    IL_006b:  ldloc.s    V_4
+    IL_006d:  brfalse.s  IL_0081
+    .line 291,291 : 9,10 ''
+    IL_006f:  nop
+    .line 292,292 : 13,55 ''
+    IL_0070:  ldloc.1
+    IL_0071:  ldc.i4.0
+    IL_0072:  ldloc.1
+    IL_0073:  callvirt   instance int32 [mscorlib]System.String::get_Length()
+    IL_0078:  ldc.i4.4
+    IL_0079:  sub
+    IL_007a:  callvirt   instance string [mscorlib]System.String::Substring(int32,
                                                                             int32)
-    IL_007a:  stloc.1
-    .line 291,291 : 9,21 ''
-    IL_007b:  ldloc.1
-    IL_007c:  stloc.s    V_5
-    IL_007e:  br.s       IL_0080
-    .line 292,292 : 5,6 ''
-    IL_0080:  ldloc.s    V_5
-    IL_0082:  ret
+    IL_007f:  stloc.1
+    .line 293,293 : 9,10 ''
+    IL_0080:  nop
+    .line 295,295 : 9,21 ''
+    IL_0081:  ldloc.1
+    IL_0082:  stloc.s    V_5
+    IL_0084:  br.s       IL_0086
+    .line 296,296 : 5,6 ''
+    IL_0086:  ldloc.s    V_5
+    IL_0088:  ret
   } // end of method AssemblyLoader::ResourceNameToPath
   .method private hidebysig static string 
           CalculateChecksum(string filename) cil managed
   {
-    // Code size       145 (0x91)
+    // Code size       144 (0x90)
     .maxstack  4
     .locals init ([0] class [mscorlib]System.IO.FileStream fs,
              [1] class [mscorlib]System.IO.BufferedStream bs,
@@ -1066,7 +1078,7 @@
              [8] string V_8)
     .line 62,62 : 5,6 ''
     IL_0000:  nop
-    .line 63,63 : 16,109 ''
+    .line 63,63 : 16,102 ''
     IL_0001:  ldarg.0
     IL_0002:  ldc.i4.3
     IL_0003:  ldc.i4.1
@@ -1076,114 +1088,112 @@
                                                                              valuetype [mscorlib]System.IO.FileAccess,
                                                                              valuetype [mscorlib]System.IO.FileShare)
     IL_000a:  stloc.0
-    .line 64,64 : 16,58 ''
+    .line 64,64 : 16,47 ''
     .try
     {
       IL_000b:  ldloc.0
       IL_000c:  newobj     instance void [mscorlib]System.IO.BufferedStream::.ctor(class [mscorlib]System.IO.Stream)
       IL_0011:  stloc.1
-      .line 65,65 : 9,10 ''
+      .line 65,65 : 16,44 ''
       .try
       {
-        IL_0012:  nop
-        .line 66,66 : 20,56 ''
-        IL_0013:  newobj     instance void [mscorlib]System.Security.Cryptography.SHA1Managed::.ctor()
-        IL_0018:  stloc.2
-        .line 67,67 : 13,14 ''
+        IL_0012:  newobj     instance void [mscorlib]System.Security.Cryptography.SHA1Managed::.ctor()
+        IL_0017:  stloc.2
+        .line 66,66 : 9,10 ''
         .try
         {
-          IL_0019:  nop
-          .line 68,68 : 17,52 ''
-          IL_001a:  ldloc.2
-          IL_001b:  ldloc.1
-          IL_001c:  callvirt   instance uint8[] [mscorlib]System.Security.Cryptography.HashAlgorithm::ComputeHash(class [mscorlib]System.IO.Stream)
-          IL_0021:  stloc.3
-          .line 69,69 : 17,78 ''
-          IL_0022:  ldc.i4.2
-          IL_0023:  ldloc.3
-          IL_0024:  ldlen
-          IL_0025:  conv.i4
-          IL_0026:  mul
-          IL_0027:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
-          IL_002c:  stloc.s    formatted
-          .line 70,70 : 17,24 ''
-          IL_002e:  nop
-          .line 70,70 : 36,40 ''
-          IL_002f:  ldloc.3
-          IL_0030:  stloc.s    
-          IL_0032:  ldc.i4.0
-          IL_0033:  stloc.s    V_6
+          IL_0018:  nop
+          .line 67,67 : 13,45 ''
+          IL_0019:  ldloc.2
+          IL_001a:  ldloc.1
+          IL_001b:  callvirt   instance uint8[] [mscorlib]System.Security.Cryptography.HashAlgorithm::ComputeHash(class [mscorlib]System.IO.Stream)
+          IL_0020:  stloc.3
+          .line 68,68 : 13,62 ''
+          IL_0021:  ldc.i4.2
+          IL_0022:  ldloc.3
+          IL_0023:  ldlen
+          IL_0024:  conv.i4
+          IL_0025:  mul
+          IL_0026:  newobj     instance void [mscorlib]System.Text.StringBuilder::.ctor(int32)
+          IL_002b:  stloc.s    formatted
+          .line 69,69 : 13,20 ''
+          IL_002d:  nop
+          .line 69,69 : 31,35 ''
+          IL_002e:  ldloc.3
+          IL_002f:  stloc.s    
+          IL_0031:  ldc.i4.0
+          IL_0032:  stloc.s    V_6
           .line 16707566,16707566 : 0,0 ''
-          IL_0035:  br.s       IL_005a
-          .line 70,70 : 26,32 ''
-          IL_0037:  ldloc.s    
-          IL_0039:  ldloc.s    V_6
-          IL_003b:  ldelem.u1
-          IL_003c:  stloc.s    b
-          .line 71,71 : 17,18 ''
-          IL_003e:  nop
-          .line 72,72 : 21,57 ''
-          IL_003f:  ldloc.s    formatted
-          IL_0041:  ldstr      "{0:X2}"
-          IL_0046:  ldloc.s    b
-          IL_0048:  box        [mscorlib]System.Byte
-          IL_004d:  callvirt   instance class [mscorlib]System.Text.StringBuilder [mscorlib]System.Text.StringBuilder::AppendFormat(string,
+          IL_0034:  br.s       IL_0059
+          .line 69,69 : 22,27 ''
+          IL_0036:  ldloc.s    
+          IL_0038:  ldloc.s    V_6
+          IL_003a:  ldelem.u1
+          IL_003b:  stloc.s    b
+          .line 70,70 : 13,14 ''
+          IL_003d:  nop
+          .line 71,71 : 17,53 ''
+          IL_003e:  ldloc.s    formatted
+          IL_0040:  ldstr      "{0:X2}"
+          IL_0045:  ldloc.s    b
+          IL_0047:  box        [mscorlib]System.Byte
+          IL_004c:  callvirt   instance class [mscorlib]System.Text.StringBuilder [mscorlib]System.Text.StringBuilder::AppendFormat(string,
                                                                                                                                     object)
-          IL_0052:  pop
-          .line 73,73 : 17,18 ''
-          IL_0053:  nop
+          IL_0051:  pop
+          .line 72,72 : 13,14 ''
+          IL_0052:  nop
           .line 16707566,16707566 : 0,0 ''
-          IL_0054:  ldloc.s    V_6
-          IL_0056:  ldc.i4.1
-          IL_0057:  add
-          IL_0058:  stloc.s    V_6
-          .line 70,70 : 33,35 ''
-          IL_005a:  ldloc.s    V_6
-          IL_005c:  ldloc.s    
-          IL_005e:  ldlen
-          IL_005f:  conv.i4
-          IL_0060:  blt.s      IL_0037
-          .line 74,74 : 17,45 ''
-          IL_0062:  ldloc.s    formatted
-          IL_0064:  callvirt   instance string [mscorlib]System.Object::ToString()
-          IL_0069:  stloc.s    V_8
-          IL_006b:  leave.s    IL_008e
+          IL_0053:  ldloc.s    V_6
+          IL_0055:  ldc.i4.1
+          IL_0056:  add
+          IL_0057:  stloc.s    V_6
+          .line 69,69 : 28,30 ''
+          IL_0059:  ldloc.s    V_6
+          IL_005b:  ldloc.s    
+          IL_005d:  ldlen
+          IL_005e:  conv.i4
+          IL_005f:  blt.s      IL_0036
+          .line 73,73 : 13,41 ''
+          IL_0061:  ldloc.s    formatted
+          IL_0063:  callvirt   instance string [mscorlib]System.Object::ToString()
+          IL_0068:  stloc.s    V_8
+          IL_006a:  leave.s    IL_008d
           .line 16707566,16707566 : 0,0 ''
         }  // end .try
         finally
         {
-          IL_006d:  ldloc.2
-          IL_006e:  brfalse.s  IL_0077
-          IL_0070:  ldloc.2
-          IL_0071:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
-          IL_0076:  nop
-          IL_0077:  endfinally
+          IL_006c:  ldloc.2
+          IL_006d:  brfalse.s  IL_0076
+          IL_006f:  ldloc.2
+          IL_0070:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+          IL_0075:  nop
+          IL_0076:  endfinally
           .line 16707566,16707566 : 0,0 ''
         }  // end handler
       }  // end .try
       finally
       {
-        IL_0078:  ldloc.1
-        IL_0079:  brfalse.s  IL_0082
-        IL_007b:  ldloc.1
-        IL_007c:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
-        IL_0081:  nop
-        IL_0082:  endfinally
+        IL_0077:  ldloc.1
+        IL_0078:  brfalse.s  IL_0081
+        IL_007a:  ldloc.1
+        IL_007b:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+        IL_0080:  nop
+        IL_0081:  endfinally
         .line 16707566,16707566 : 0,0 ''
       }  // end handler
     }  // end .try
     finally
     {
-      IL_0083:  ldloc.0
-      IL_0084:  brfalse.s  IL_008d
-      IL_0086:  ldloc.0
-      IL_0087:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
-      IL_008c:  nop
-      IL_008d:  endfinally
-      .line 77,77 : 5,6 ''
+      IL_0082:  ldloc.0
+      IL_0083:  brfalse.s  IL_008c
+      IL_0085:  ldloc.0
+      IL_0086:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+      IL_008b:  nop
+      IL_008c:  endfinally
+      .line 75,75 : 5,6 ''
     }  // end handler
-    IL_008e:  ldloc.s    V_8
-    IL_0090:  ret
+    IL_008d:  ldloc.s    V_8
+    IL_008f:  ret
   } // end of method AssemblyLoader::CalculateChecksum
   .method private hidebysig static pinvokeimpl("kernel32.dll" unicode lasterr winapi) 
           bool  MoveFileEx(string lpExistingFileName,
@@ -1220,11 +1230,11 @@
              [12] string V_12,
              [13] bool V_13,
              [14] string V_14)
-    .line 232,232 : 5,6 ''
+    .line 230,230 : 5,6 ''
     IL_0000:  nop
-    .line 235,235 : 9,16 ''
+    .line 233,233 : 9,16 ''
     IL_0001:  nop
-    .line 235,235 : 29,33 ''
+    .line 233,233 : 29,33 ''
     IL_0002:  ldarg.1
     IL_0003:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
     IL_0008:  stloc.1
@@ -1232,36 +1242,36 @@
     .try
     {
       IL_0009:  br         IL_00b5
-      .line 235,235 : 18,25 ''
+      .line 233,233 : 18,25 ''
       IL_000e:  ldloc.1
       IL_000f:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
       IL_0014:  stloc.2
-      .line 236,236 : 9,10 ''
+      .line 234,234 : 9,10 ''
       IL_0015:  nop
-      .line 237,237 : 13,44 ''
+      .line 235,235 : 13,44 ''
       IL_0016:  ldloc.2
       IL_0017:  call       string Costura.AssemblyLoader::ResourceNameToPath(string)
       IL_001c:  stloc.0
-      .line 239,239 : 13,73 ''
+      .line 237,237 : 13,73 ''
       IL_001d:  ldarg.0
       IL_001e:  ldloc.0
       IL_001f:  call       string [mscorlib]System.IO.Path::Combine(string,
                                                                     string)
       IL_0024:  stloc.3
-      .line 241,241 : 13,51 ''
+      .line 239,239 : 13,51 ''
       IL_0025:  ldloc.3
       IL_0026:  call       bool [mscorlib]System.IO.File::Exists(string)
       IL_002b:  stloc.s    V_4
       .line 16707566,16707566 : 0,0 ''
       IL_002d:  ldloc.s    V_4
       IL_002f:  brfalse.s  IL_0056
-      .line 242,242 : 13,14 ''
+      .line 240,240 : 13,14 ''
       IL_0031:  nop
-      .line 243,243 : 17,72 ''
+      .line 241,241 : 17,72 ''
       IL_0032:  ldloc.3
       IL_0033:  call       string Costura.AssemblyLoader::CalculateChecksum(string)
       IL_0038:  stloc.s    checksum
-      .line 244,244 : 17,48 ''
+      .line 242,242 : 17,48 ''
       IL_003a:  ldloc.s    checksum
       IL_003c:  ldarg.2
       IL_003d:  ldloc.2
@@ -1272,13 +1282,13 @@
       .line 16707566,16707566 : 0,0 ''
       IL_004a:  ldloc.s    V_6
       IL_004c:  brfalse.s  IL_0055
-      .line 245,245 : 21,55 ''
+      .line 243,243 : 21,55 ''
       IL_004e:  ldloc.3
       IL_004f:  call       void [mscorlib]System.IO.File::Delete(string)
       IL_0054:  nop
-      .line 246,246 : 13,14 ''
+      .line 244,244 : 13,14 ''
       IL_0055:  nop
-      .line 248,248 : 13,52 ''
+      .line 246,246 : 13,52 ''
       IL_0056:  ldloc.3
       IL_0057:  call       bool [mscorlib]System.IO.File::Exists(string)
       IL_005c:  ldc.i4.0
@@ -1287,29 +1297,29 @@
       .line 16707566,16707566 : 0,0 ''
       IL_0061:  ldloc.s    V_7
       IL_0063:  brfalse.s  IL_00b4
-      .line 249,249 : 13,14 ''
+      .line 247,247 : 13,14 ''
       IL_0065:  nop
-      .line 250,250 : 24,56 ''
+      .line 248,248 : 24,56 ''
       IL_0066:  ldloc.2
       IL_0067:  call       class [mscorlib]System.IO.Stream Costura.AssemblyLoader::LoadStream(string)
       IL_006c:  stloc.s    copyStream
-      .line 251,251 : 24,83 ''
+      .line 249,249 : 24,83 ''
       .try
       {
         IL_006e:  ldloc.3
         IL_006f:  call       class [mscorlib]System.IO.FileStream [mscorlib]System.IO.File::OpenWrite(string)
         IL_0074:  stloc.s    assemblyTempFile
-        .line 252,252 : 17,18 ''
+        .line 250,250 : 17,18 ''
         .try
         {
           IL_0076:  nop
-          .line 253,253 : 21,58 ''
+          .line 251,251 : 21,58 ''
           IL_0077:  ldloc.s    copyStream
           IL_0079:  ldloc.s    assemblyTempFile
           IL_007b:  call       void Costura.AssemblyLoader::CopyTo(class [mscorlib]System.IO.Stream,
                                                                    class [mscorlib]System.IO.Stream)
           IL_0080:  nop
-          .line 254,254 : 17,18 ''
+          .line 252,252 : 17,18 ''
           IL_0081:  nop
           IL_0082:  leave.s    IL_0091
           .line 16707566,16707566 : 0,0 ''
@@ -1335,7 +1345,7 @@
         IL_0099:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
         IL_009e:  nop
         IL_009f:  endfinally
-        .line 255,255 : 17,79 ''
+        .line 253,253 : 17,79 ''
       }  // end handler
       IL_00a0:  ldloc.3
       IL_00a1:  ldnull
@@ -1349,15 +1359,15 @@
       .line 16707566,16707566 : 0,0 ''
       IL_00ad:  ldloc.s    V_10
       IL_00af:  brfalse.s  IL_00b3
-      .line 256,256 : 17,18 ''
+      .line 254,254 : 17,18 ''
       IL_00b1:  nop
-      .line 258,258 : 17,18 ''
+      .line 256,256 : 17,18 ''
       IL_00b2:  nop
-      .line 259,259 : 13,14 ''
+      .line 257,257 : 13,14 ''
       IL_00b3:  nop
-      .line 260,260 : 9,10 ''
+      .line 258,258 : 9,10 ''
       IL_00b4:  nop
-      .line 235,235 : 26,28 ''
+      .line 233,233 : 26,28 ''
       IL_00b5:  ldloc.1
       IL_00b6:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
       IL_00bb:  brtrue     IL_000e
@@ -1372,14 +1382,14 @@
       IL_00c6:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_00cb:  nop
       IL_00cc:  endfinally
-      .line 262,262 : 9,39 ''
+      .line 260,260 : 9,39 ''
     }  // end handler
     IL_00cd:  ldarg.0
     IL_00ce:  call       bool Costura.AssemblyLoader::SetDllDirectory(string)
     IL_00d3:  pop
-    .line 264,264 : 9,16 ''
+    .line 262,262 : 9,16 ''
     IL_00d4:  nop
-    .line 264,264 : 29,33 ''
+    .line 262,262 : 29,33 ''
     IL_00d5:  ldarg.1
     IL_00d6:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
     IL_00db:  stloc.s    V_11
@@ -1387,17 +1397,17 @@
     .try
     {
       IL_00dd:  br.s       IL_0116
-      .line 264,264 : 18,25 ''
+      .line 262,262 : 18,25 ''
       IL_00df:  ldloc.s    V_11
       IL_00e1:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
       IL_00e6:  stloc.s    V_12
-      .line 265,265 : 9,10 ''
+      .line 263,263 : 9,10 ''
       IL_00e8:  nop
-      .line 266,266 : 13,44 ''
+      .line 264,264 : 13,44 ''
       IL_00e9:  ldloc.s    V_12
       IL_00eb:  call       string Costura.AssemblyLoader::ResourceNameToPath(string)
       IL_00f0:  stloc.0
-      .line 268,268 : 13,39 ''
+      .line 266,266 : 13,39 ''
       IL_00f1:  ldloc.0
       IL_00f2:  ldstr      ".dll"
       IL_00f7:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
@@ -1405,23 +1415,23 @@
       .line 16707566,16707566 : 0,0 ''
       IL_00fe:  ldloc.s    V_13
       IL_0100:  brfalse.s  IL_0115
-      .line 269,269 : 13,14 ''
+      .line 267,267 : 13,14 ''
       IL_0102:  nop
-      .line 270,270 : 17,77 ''
+      .line 268,268 : 17,77 ''
       IL_0103:  ldarg.0
       IL_0104:  ldloc.0
       IL_0105:  call       string [mscorlib]System.IO.Path::Combine(string,
                                                                     string)
       IL_010a:  stloc.s    V_14
-      .line 272,272 : 17,51 ''
+      .line 270,270 : 17,51 ''
       IL_010c:  ldloc.s    V_14
       IL_010e:  call       native int Costura.AssemblyLoader::LoadLibrary(string)
       IL_0113:  pop
-      .line 273,273 : 13,14 ''
+      .line 271,271 : 13,14 ''
       IL_0114:  nop
-      .line 274,274 : 9,10 ''
+      .line 272,272 : 9,10 ''
       IL_0115:  nop
-      .line 264,264 : 26,28 ''
+      .line 262,262 : 26,28 ''
       IL_0116:  ldloc.s    V_11
       IL_0118:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
       IL_011d:  brtrue.s   IL_00df
@@ -1436,7 +1446,7 @@
       IL_0127:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_012c:  nop
       IL_012d:  endfinally
-      .line 275,275 : 5,6 ''
+      .line 273,273 : 5,6 ''
     }  // end handler
     IL_012e:  ret
   } // end of method AssemblyLoader::InternalPreloadUnmanagedLibraries
@@ -1455,25 +1465,25 @@
              [5] string bittyness,
              [6] bool ,
              [7] bool V_7)
-    .line 195,195 : 5,6 ''
+    .line 193,193 : 5,6 ''
     IL_0000:  nop
-    .line 196,196 : 9,68 ''
+    .line 194,194 : 9,65 ''
     IL_0001:  ldstr      "Global\\Costura{0}"
     IL_0006:  ldarg.0
     IL_0007:  call       string [mscorlib]System.String::Format(string,
                                                                 object)
     IL_000c:  stloc.0
-    .line 198,198 : 16,53 ''
+    .line 196,196 : 16,53 ''
     IL_000d:  ldc.i4.0
     IL_000e:  ldloc.0
     IL_000f:  newobj     instance void [mscorlib]System.Threading.Mutex::.ctor(bool,
                                                                                string)
     IL_0014:  stloc.1
-    .line 199,199 : 9,10 ''
+    .line 197,197 : 9,10 ''
     .try
     {
       IL_0015:  nop
-      .line 200,200 : 13,164 ''
+      .line 198,198 : 13,164 ''
       IL_0016:  ldc.i4.1
       IL_0017:  ldnull
       IL_0018:  newobj     instance void [mscorlib]System.Security.Principal.SecurityIdentifier::.ctor(valuetype [mscorlib]System.Security.Principal.WellKnownSidType,
@@ -1484,38 +1494,38 @@
                                                                                                         valuetype [mscorlib]System.Security.AccessControl.MutexRights,
                                                                                                         valuetype [mscorlib]System.Security.AccessControl.AccessControlType)
       IL_0028:  stloc.2
-      .line 201,201 : 13,56 ''
+      .line 199,199 : 13,56 ''
       IL_0029:  newobj     instance void [mscorlib]System.Security.AccessControl.MutexSecurity::.ctor()
       IL_002e:  stloc.3
-      .line 202,202 : 13,63 ''
+      .line 200,200 : 13,63 ''
       IL_002f:  ldloc.3
       IL_0030:  ldloc.2
       IL_0031:  callvirt   instance void [mscorlib]System.Security.AccessControl.MutexSecurity::AddAccessRule(class [mscorlib]System.Security.AccessControl.MutexAccessRule)
       IL_0036:  nop
-      .line 203,203 : 13,54 ''
+      .line 201,201 : 13,54 ''
       IL_0037:  ldloc.1
       IL_0038:  ldloc.3
       IL_0039:  callvirt   instance void [mscorlib]System.Threading.Mutex::SetAccessControl(class [mscorlib]System.Security.AccessControl.MutexSecurity)
       IL_003e:  nop
-      .line 205,205 : 13,35 ''
+      .line 203,203 : 13,35 ''
       IL_003f:  ldc.i4.0
       IL_0040:  stloc.s    hasHandle
-      .line 207,207 : 13,14 ''
+      .line 205,205 : 13,14 ''
       .try
       {
         IL_0042:  nop
-        .line 209,209 : 17,18 ''
+        .line 207,207 : 17,18 ''
         .try
         {
           IL_0043:  nop
-          .line 210,210 : 21,61 ''
+          .line 208,208 : 21,61 ''
           IL_0044:  ldloc.1
           IL_0045:  ldc.i4     0xea60
           IL_004a:  ldc.i4.0
           IL_004b:  callvirt   instance bool [mscorlib]System.Threading.WaitHandle::WaitOne(int32,
                                                                                             bool)
           IL_0050:  stloc.s    hasHandle
-          .line 211,211 : 21,44 ''
+          .line 209,209 : 21,44 ''
           IL_0052:  ldloc.s    hasHandle
           IL_0054:  ldc.i4.0
           IL_0055:  ceq
@@ -1523,27 +1533,27 @@
           .line 16707566,16707566 : 0,0 ''
           IL_0059:  ldloc.s    
           IL_005b:  brfalse.s  IL_0068
-          .line 212,212 : 25,92 ''
+          .line 210,210 : 25,92 ''
           IL_005d:  ldstr      "Timeout waiting for exclusive access"
           IL_0062:  newobj     instance void [mscorlib]System.TimeoutException::.ctor(string)
           IL_0067:  throw
-          .line 213,213 : 17,18 ''
+          .line 211,211 : 17,18 ''
           IL_0068:  nop
           IL_0069:  leave.s    IL_0073
-          .line 214,214 : 17,48 ''
+          .line 212,212 : 17,48 ''
         }  // end .try
         catch [mscorlib]System.Threading.AbandonedMutexException 
         {
           IL_006b:  pop
-          .line 215,215 : 17,18 ''
+          .line 213,213 : 17,18 ''
           IL_006c:  nop
-          .line 216,216 : 21,38 ''
+          .line 214,214 : 21,38 ''
           IL_006d:  ldc.i4.1
           IL_006e:  stloc.s    hasHandle
-          .line 217,217 : 17,18 ''
+          .line 215,215 : 17,18 ''
           IL_0070:  nop
           IL_0071:  leave.s    IL_0073
-          .line 219,219 : 17,64 ''
+          .line 217,217 : 17,64 ''
         }  // end handler
         IL_0073:  call       int32 [mscorlib]System.IntPtr::get_Size()
         IL_0078:  ldc.i4.8
@@ -1552,14 +1562,14 @@
         IL_0080:  br.s       IL_0087
         IL_0082:  ldstr      "64"
         IL_0087:  stloc.s    bittyness
-        .line 220,220 : 17,72 ''
+        .line 218,218 : 17,72 ''
         IL_0089:  ldarg.1
         IL_008a:  ldloc.s    bittyness
         IL_008c:  call       string [mscorlib]System.IO.Path::Combine(string,
                                                                       string)
         IL_0091:  call       void Costura.AssemblyLoader::CreateDirectory(string)
         IL_0096:  nop
-        .line 221,221 : 17,82 ''
+        .line 219,219 : 17,82 ''
         IL_0097:  ldarg.1
         IL_0098:  ldarg.2
         IL_0099:  ldarg.3
@@ -1567,28 +1577,28 @@
                                                                                             class [mscorlib]System.Collections.Generic.IEnumerable`1<string>,
                                                                                             class [mscorlib]System.Collections.Generic.Dictionary`2<string,string>)
         IL_009f:  nop
-        .line 222,222 : 13,14 ''
+        .line 220,220 : 13,14 ''
         IL_00a0:  nop
         IL_00a1:  leave.s    IL_00b5
-        .line 224,224 : 13,14 ''
+        .line 222,222 : 13,14 ''
       }  // end .try
       finally
       {
         IL_00a3:  nop
-        .line 225,225 : 17,31 ''
+        .line 223,223 : 17,31 ''
         IL_00a4:  ldloc.s    hasHandle
         IL_00a6:  stloc.s    V_7
         .line 16707566,16707566 : 0,0 ''
         IL_00a8:  ldloc.s    V_7
         IL_00aa:  brfalse.s  IL_00b3
-        .line 226,226 : 21,42 ''
+        .line 224,224 : 21,42 ''
         IL_00ac:  ldloc.1
         IL_00ad:  callvirt   instance void [mscorlib]System.Threading.Mutex::ReleaseMutex()
         IL_00b2:  nop
-        .line 227,227 : 13,14 ''
+        .line 225,225 : 13,14 ''
         IL_00b3:  nop
         IL_00b4:  endfinally
-        .line 228,228 : 9,10 ''
+        .line 226,226 : 9,10 ''
       }  // end handler
       IL_00b5:  nop
       IL_00b6:  leave.s    IL_00c3
@@ -1602,7 +1612,7 @@
       IL_00bc:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_00c1:  nop
       IL_00c2:  endfinally
-      .line 229,229 : 5,6 ''
+      .line 227,227 : 5,6 ''
     }  // end handler
     IL_00c3:  ret
   } // end of method AssemblyLoader::PreloadUnmanagedLibraries

--- a/Tests/InMemoryTests.cs
+++ b/Tests/InMemoryTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
+using ApprovalTests;
 using ApprovalTests.Reporters;
 using Mono.Cecil;
 using NUnit.Framework;

--- a/Tests/PureDotNetAssemblyTests.TemplateHasCorrectSymbols.approved.txt
+++ b/Tests/PureDotNetAssemblyTests.TemplateHasCorrectSymbols.approved.txt
@@ -163,9 +163,9 @@
     .maxstack  2
     .locals init ([0] bool ,
              [1] string V_1)
-    .line 98,98 : 5,6 'AssemblyToProcessWithoutUnmanaged\\bin\\Debug\\Common.cs'
+    .line 96,96 : 5,6 'AssemblyToProcessWithoutUnmanaged\\bin\\Debug\\Common.cs'
     IL_0000:  nop
-    .line 99,99 : 9,29 ''
+    .line 97,97 : 9,29 ''
     IL_0001:  ldarg.0
     IL_0002:  ldnull
     IL_0003:  ceq
@@ -173,16 +173,16 @@
     .line 16707566,16707566 : 0,0 ''
     IL_0006:  ldloc.0
     IL_0007:  brfalse.s  IL_0011
-    .line 100,100 : 13,23 ''
+    .line 98,98 : 13,23 ''
     IL_0009:  ldstr      ""
     IL_000e:  stloc.1
     IL_000f:  br.s       IL_001a
-    .line 102,102 : 9,29 ''
+    .line 100,100 : 9,29 ''
     IL_0011:  ldarg.0
     IL_0012:  callvirt   instance string [mscorlib]System.Globalization.CultureInfo::get_Name()
     IL_0017:  stloc.1
     IL_0018:  br.s       IL_001a
-    .line 103,103 : 5,6 ''
+    .line 101,101 : 5,6 ''
     IL_001a:  ldloc.1
     IL_001b:  ret
   } // end of method AssemblyLoader::CultureToString
@@ -219,36 +219,36 @@
              [5] class [mscorlib]System.Reflection.AssemblyName currentName,
              [6] bool V_6,
              [7] class [mscorlib]System.Reflection.Assembly V_7)
-    .line 80,80 : 5,6 ''
+    .line 78,78 : 5,6 ''
     IL_0000:  nop
-    .line 81,81 : 9,53 ''
+    .line 79,79 : 9,53 ''
     IL_0001:  call       class [mscorlib]System.AppDomain [mscorlib]System.AppDomain::get_CurrentDomain()
     IL_0006:  stloc.0
-    .line 82,82 : 9,56 ''
+    .line 80,80 : 9,56 ''
     IL_0007:  ldloc.0
     IL_0008:  callvirt   instance class [mscorlib]System.Reflection.Assembly[] [mscorlib]System.AppDomain::GetAssemblies()
     IL_000d:  stloc.1
-    .line 83,83 : 9,16 ''
+    .line 81,81 : 9,16 ''
     IL_000e:  nop
-    .line 83,83 : 34,44 ''
+    .line 81,81 : 34,44 ''
     IL_000f:  ldloc.1
     IL_0010:  stloc.2
     IL_0011:  ldc.i4.0
     IL_0012:  stloc.3
     .line 16707566,16707566 : 0,0 ''
     IL_0013:  br.s       IL_0086
-    .line 83,83 : 18,30 ''
+    .line 81,81 : 18,30 ''
     IL_0015:  ldloc.2
     IL_0016:  ldloc.3
     IL_0017:  ldelem.ref
     IL_0018:  stloc.s    'assembly'
-    .line 84,84 : 9,10 ''
+    .line 82,82 : 9,10 ''
     IL_001a:  nop
-    .line 85,85 : 13,50 ''
+    .line 83,83 : 13,50 ''
     IL_001b:  ldloc.s    'assembly'
     IL_001d:  callvirt   instance class [mscorlib]System.Reflection.AssemblyName [mscorlib]System.Reflection.Assembly::GetName()
     IL_0022:  stloc.s    currentName
-    .line 86,87 : 13,153 ''
+    .line 84,85 : 13,153 ''
     IL_0024:  ldloc.s    currentName
     IL_0026:  callvirt   instance string [mscorlib]System.Reflection.AssemblyName::get_Name()
     IL_002b:  ldarg.0
@@ -274,9 +274,9 @@
     .line 16707566,16707566 : 0,0 ''
     IL_005b:  ldloc.s    V_6
     IL_005d:  brfalse.s  IL_0081
-    .line 88,88 : 13,14 ''
+    .line 86,86 : 13,14 ''
     IL_005f:  nop
-    .line 89,89 : 17,102 ''
+    .line 87,87 : 17,102 ''
     IL_0060:  ldstr      "Assembly '{0}' already loaded, returning existing "
     + "assembly"
     IL_0065:  ldc.i4.1
@@ -289,28 +289,28 @@
     IL_0075:  call       void Costura.AssemblyLoader::Log(string,
                                                           object[])
     IL_007a:  nop
-    .line 91,91 : 17,33 ''
+    .line 89,89 : 17,33 ''
     IL_007b:  ldloc.s    'assembly'
     IL_007d:  stloc.s    V_7
     IL_007f:  br.s       IL_0091
-    .line 93,93 : 9,10 ''
+    .line 91,91 : 9,10 ''
     IL_0081:  nop
     .line 16707566,16707566 : 0,0 ''
     IL_0082:  ldloc.3
     IL_0083:  ldc.i4.1
     IL_0084:  add
     IL_0085:  stloc.3
-    .line 83,83 : 31,33 ''
+    .line 81,81 : 31,33 ''
     IL_0086:  ldloc.3
     IL_0087:  ldloc.2
     IL_0088:  ldlen
     IL_0089:  conv.i4
     IL_008a:  blt.s      IL_0015
-    .line 94,94 : 9,21 ''
+    .line 92,92 : 9,21 ''
     IL_008c:  ldnull
     IL_008d:  stloc.s    V_7
     IL_008f:  br.s       IL_0091
-    .line 95,95 : 5,6 ''
+    .line 93,93 : 5,6 ''
     IL_0091:  ldloc.s    V_7
     IL_0093:  ret
   } // end of method AssemblyLoader::ReadExistingAssembly
@@ -375,12 +375,12 @@
              [3] class [System]System.IO.Compression.DeflateStream compressStream,
              [4] class [mscorlib]System.IO.MemoryStream memStream,
              [5] class [mscorlib]System.IO.Stream V_5)
-    .line 175,175 : 5,6 ''
+    .line 173,173 : 5,6 ''
     IL_0000:  nop
-    .line 176,176 : 9,65 ''
+    .line 174,174 : 9,65 ''
     IL_0001:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::GetExecutingAssembly()
     IL_0006:  stloc.0
-    .line 178,178 : 9,39 ''
+    .line 176,176 : 9,39 ''
     IL_0007:  ldarg.0
     IL_0008:  ldstr      ".zip"
     IL_000d:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
@@ -388,14 +388,14 @@
     .line 16707566,16707566 : 0,0 ''
     IL_0013:  ldloc.1
     IL_0014:  brfalse.s  IL_005e
-    .line 179,179 : 9,10 ''
+    .line 177,177 : 9,10 ''
     IL_0016:  nop
-    .line 180,180 : 20,86 ''
+    .line 178,178 : 20,86 ''
     IL_0017:  ldloc.0
     IL_0018:  ldarg.0
     IL_0019:  callvirt   instance class [mscorlib]System.IO.Stream [mscorlib]System.Reflection.Assembly::GetManifestResourceStream(string)
     IL_001e:  stloc.2
-    .line 181,181 : 20,94 ''
+    .line 179,179 : 20,94 ''
     .try
     {
       IL_001f:  ldloc.2
@@ -403,26 +403,26 @@
       IL_0021:  newobj     instance void [System]System.IO.Compression.DeflateStream::.ctor(class [mscorlib]System.IO.Stream,
                                                                                             valuetype [System]System.IO.Compression.CompressionMode)
       IL_0026:  stloc.3
-      .line 182,182 : 13,14 ''
+      .line 180,180 : 13,14 ''
       .try
       {
         IL_0027:  nop
-        .line 183,183 : 17,52 ''
+        .line 181,181 : 17,52 ''
         IL_0028:  newobj     instance void [mscorlib]System.IO.MemoryStream::.ctor()
         IL_002d:  stloc.s    memStream
-        .line 184,184 : 17,51 ''
+        .line 182,182 : 17,51 ''
         IL_002f:  ldloc.3
         IL_0030:  ldloc.s    memStream
         IL_0032:  call       void Costura.AssemblyLoader::CopyTo(class [mscorlib]System.IO.Stream,
                                                                  class [mscorlib]System.IO.Stream)
         IL_0037:  nop
-        .line 185,185 : 17,40 ''
+        .line 183,183 : 17,40 ''
         IL_0038:  ldloc.s    memStream
         IL_003a:  ldc.i4.0
         IL_003b:  conv.i8
         IL_003c:  callvirt   instance void [mscorlib]System.IO.Stream::set_Position(int64)
         IL_0041:  nop
-        .line 186,186 : 17,34 ''
+        .line 184,184 : 17,34 ''
         IL_0042:  ldloc.s    memStream
         IL_0044:  stloc.s    V_5
         IL_0046:  leave.s    IL_0069
@@ -447,14 +447,14 @@
       IL_0057:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_005c:  nop
       IL_005d:  endfinally
-      .line 190,190 : 9,70 ''
+      .line 188,188 : 9,70 ''
     }  // end handler
     IL_005e:  ldloc.0
     IL_005f:  ldarg.0
     IL_0060:  callvirt   instance class [mscorlib]System.IO.Stream [mscorlib]System.Reflection.Assembly::GetManifestResourceStream(string)
     IL_0065:  stloc.s    V_5
     IL_0067:  br.s       IL_0069
-    .line 191,191 : 5,6 ''
+    .line 189,189 : 5,6 ''
     IL_0069:  ldloc.s    V_5
     IL_006b:  ret
   } // end of method AssemblyLoader::LoadStream
@@ -467,9 +467,9 @@
     .locals init ([0] string 'value',
              [1] bool ,
              [2] class [mscorlib]System.IO.Stream V_2)
-    .line 166,166 : 5,6 ''
+    .line 164,164 : 5,6 ''
     IL_0000:  nop
-    .line 168,168 : 9,56 ''
+    .line 166,166 : 9,56 ''
     IL_0001:  ldarg.0
     IL_0002:  ldarg.1
     IL_0003:  ldloca.s   'value'
@@ -479,16 +479,16 @@
     .line 16707566,16707566 : 0,0 ''
     IL_000b:  ldloc.1
     IL_000c:  brfalse.s  IL_0017
-    .line 169,169 : 13,38 ''
+    .line 167,167 : 13,38 ''
     IL_000e:  ldloc.0
     IL_000f:  call       class [mscorlib]System.IO.Stream Costura.AssemblyLoader::LoadStream(string)
     IL_0014:  stloc.2
     IL_0015:  br.s       IL_001b
-    .line 171,171 : 9,21 ''
+    .line 169,169 : 9,21 ''
     IL_0017:  ldnull
     IL_0018:  stloc.2
     IL_0019:  br.s       IL_001b
-    .line 172,172 : 5,6 ''
+    .line 170,170 : 5,6 ''
     IL_001b:  ldloc.2
     IL_001c:  ret
   } // end of method AssemblyLoader::LoadStream
@@ -542,14 +542,14 @@
              [6] class [mscorlib]System.IO.Stream pdbStream,
              [7] bool V_7,
              [8] uint8[] pdbData)
-    .line 137,137 : 5,6 ''
+    .line 135,135 : 5,6 ''
     IL_0000:  nop
-    .line 138,138 : 9,66 ''
+    .line 136,136 : 9,66 ''
     IL_0001:  ldarg.2
     IL_0002:  callvirt   instance string [mscorlib]System.Reflection.AssemblyName::get_Name()
     IL_0007:  callvirt   instance string [mscorlib]System.String::ToLowerInvariant()
     IL_000c:  stloc.0
-    .line 140,140 : 9,120 ''
+    .line 138,138 : 9,120 ''
     IL_000d:  ldarg.2
     IL_000e:  callvirt   instance class [mscorlib]System.Globalization.CultureInfo [mscorlib]System.Reflection.AssemblyName::get_CultureInfo()
     IL_0013:  brfalse.s  IL_002a
@@ -565,7 +565,7 @@
     .line 16707566,16707566 : 0,0 ''
     IL_002c:  ldloc.2
     IL_002d:  brfalse.s  IL_0046
-    .line 141,141 : 13,91 ''
+    .line 139,139 : 13,91 ''
     IL_002f:  ldstr      "{0}.{1}"
     IL_0034:  ldarg.2
     IL_0035:  callvirt   instance class [mscorlib]System.Globalization.CultureInfo [mscorlib]System.Reflection.AssemblyName::get_CultureInfo()
@@ -575,17 +575,17 @@
                                                                 object,
                                                                 object)
     IL_0045:  stloc.0
-    .line 144,144 : 16,68 ''
+    .line 142,142 : 16,68 ''
     IL_0046:  ldarg.0
     IL_0047:  ldloc.0
     IL_0048:  call       class [mscorlib]System.IO.Stream Costura.AssemblyLoader::LoadStream(class [mscorlib]System.Collections.Generic.Dictionary`2<string,string>,
                                                                                              string)
     IL_004d:  stloc.3
-    .line 145,145 : 9,10 ''
+    .line 143,143 : 9,10 ''
     .try
     {
       IL_004e:  nop
-      .line 146,146 : 13,40 ''
+      .line 144,144 : 13,40 ''
       IL_004f:  ldloc.3
       IL_0050:  ldnull
       IL_0051:  ceq
@@ -593,17 +593,17 @@
       .line 16707566,16707566 : 0,0 ''
       IL_0055:  ldloc.s    V_4
       IL_0057:  brfalse.s  IL_005f
-      .line 147,147 : 13,14 ''
+      .line 145,145 : 13,14 ''
       IL_0059:  nop
-      .line 148,148 : 17,29 ''
+      .line 146,146 : 17,29 ''
       IL_005a:  ldnull
       IL_005b:  stloc.s    V_5
       IL_005d:  leave.s    IL_00b9
-      .line 150,150 : 13,55 ''
+      .line 148,148 : 13,55 ''
       IL_005f:  ldloc.3
       IL_0060:  call       uint8[] Costura.AssemblyLoader::ReadStream(class [mscorlib]System.IO.Stream)
       IL_0065:  stloc.1
-      .line 151,151 : 9,10 ''
+      .line 149,149 : 9,10 ''
       IL_0066:  nop
       IL_0067:  leave.s    IL_0074
       .line 16707566,16707566 : 0,0 ''
@@ -616,18 +616,18 @@
       IL_006d:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_0072:  nop
       IL_0073:  endfinally
-      .line 153,153 : 16,61 ''
+      .line 151,151 : 16,61 ''
     }  // end handler
     IL_0074:  ldarg.1
     IL_0075:  ldloc.0
     IL_0076:  call       class [mscorlib]System.IO.Stream Costura.AssemblyLoader::LoadStream(class [mscorlib]System.Collections.Generic.Dictionary`2<string,string>,
                                                                                              string)
     IL_007b:  stloc.s    pdbStream
-    .line 154,154 : 9,10 ''
+    .line 152,152 : 9,10 ''
     .try
     {
       IL_007d:  nop
-      .line 155,155 : 13,35 ''
+      .line 153,153 : 13,35 ''
       IL_007e:  ldloc.s    pdbStream
       IL_0080:  ldnull
       IL_0081:  cgt.un
@@ -635,20 +635,20 @@
       .line 16707566,16707566 : 0,0 ''
       IL_0085:  ldloc.s    V_7
       IL_0087:  brfalse.s  IL_009f
-      .line 156,156 : 13,14 ''
+      .line 154,154 : 13,14 ''
       IL_0089:  nop
-      .line 157,157 : 17,53 ''
+      .line 155,155 : 17,53 ''
       IL_008a:  ldloc.s    pdbStream
       IL_008c:  call       uint8[] Costura.AssemblyLoader::ReadStream(class [mscorlib]System.IO.Stream)
       IL_0091:  stloc.s    pdbData
-      .line 158,158 : 17,61 ''
+      .line 156,156 : 17,61 ''
       IL_0093:  ldloc.1
       IL_0094:  ldloc.s    pdbData
       IL_0096:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::Load(uint8[],
                                                                                                                  uint8[])
       IL_009b:  stloc.s    V_5
       IL_009d:  leave.s    IL_00b9
-      .line 160,160 : 9,10 ''
+      .line 158,158 : 9,10 ''
       IL_009f:  nop
       IL_00a0:  leave.s    IL_00af
       .line 16707566,16707566 : 0,0 ''
@@ -661,13 +661,13 @@
       IL_00a8:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
       IL_00ad:  nop
       IL_00ae:  endfinally
-      .line 162,162 : 9,44 ''
+      .line 160,160 : 9,44 ''
     }  // end handler
     IL_00af:  ldloc.1
     IL_00b0:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::Load(uint8[])
     IL_00b5:  stloc.s    V_5
     IL_00b7:  br.s       IL_00b9
-    .line 163,163 : 5,6 ''
+    .line 161,161 : 5,6 ''
     IL_00b9:  ldloc.s    V_5
     IL_00bb:  ret
   } // end of method AssemblyLoader::ReadFromEmbeddedResources

--- a/Tests/PureDotNetAssemblyTests.cs
+++ b/Tests/PureDotNetAssemblyTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Xml.Linq;
+using ApprovalTests;
 using ApprovalTests.Reporters;
 using Mono.Cecil;
 using NUnit.Framework;


### PR DESCRIPTION
Because Costura was resolving generic methods (dictionary methods) too early, it didn't work on NET45. This is resolved in this PR. Also added additional logging in case no resources were embedded (so the user at least knows it has ran Costura).