### PR TITLE
Use FIPS compliant Sha1 algorithm.

### DIFF
--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -62,7 +62,7 @@ static class Common
     {
         using (var fs = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
         using (var bs = new BufferedStream(fs))
-        using (var sha1 = new SHA1Managed())
+        using (var sha1 = new SHA1CryptoServiceProvider())
         {
             var hash = sha1.ComputeHash(bs);
             var formatted = new StringBuilder(2 * hash.Length);

--- a/src/Costura/Checksums.cs
+++ b/src/Costura/Checksums.cs
@@ -21,7 +21,7 @@ partial class ModuleWeaver
     {
         using (BufferedStream bs = new BufferedStream(stream))
         {
-            using (SHA1Managed sha1 = new SHA1Managed())
+            using (SHA1CryptoServiceProvider sha1 = new SHA1CryptoServiceProvider())
             {
                 byte[] hash = sha1.ComputeHash(bs);
                 StringBuilder formatted = new StringBuilder(2 * hash.Length);


### PR DESCRIPTION
If FIPS (see https://blogs.msdn.microsoft.com/shawnfa/2005/05/16/enforcing-fips-certified-cryptography/) was enabled, Costura will throw exceptions.