### PR TITLE
Added support for Install-CleanReferencesTarget back in

### DIFF
--- a/src/BuildNuGetPackage/Assets/commands.psm1
+++ b/src/BuildNuGetPackage/Assets/commands.psm1
@@ -1,0 +1,106 @@
+﻿function Resolve-ProjectName {
+    param(
+        [parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]$ProjectName
+    )
+    
+    if($ProjectName) {
+        $projects = Get-Project $ProjectName
+    }
+    else {
+        # All projects by default
+        $projects = Get-Project
+    }
+    
+    $projects
+}
+
+function Get-MSBuildProject {
+    param(
+        [parameter(ValueFromPipelineByPropertyName = $true)]
+        [string[]]$ProjectName
+    )
+    Process {
+        (Resolve-ProjectName $ProjectName) | % {
+            $path = $_.FullName
+            @([Microsoft.Build.Evaluation.ProjectCollection]::GlobalProjectCollection.GetLoadedProjects($path))[0]
+        }
+    }
+}
+
+function Install-CleanReferencesTarget()
+{
+    $buildProject = Get-MSBuildProject
+
+    if ($buildProject.Xml.Targets | Where-Object { "CleanReferenceCopyLocalPaths" -contains $_.Name })
+    {
+        Write-Host "Target CleanReferenceCopyLocalPaths already exists." -foregroundcolor Black -backgroundcolor Yellow
+
+        return
+    }
+
+    $usingTask = $buildProject.Xml.AddUsingTask("CosturaCleanup", "`$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll", "")
+	$usingTask.TaskFactory = "CodeTaskFactory"
+    $parameterGroup = $usingTask.AddParameterGroup()
+    $configParam = $parameterGroup.AddParameter("Config", "false", "true", "Microsoft.Build.Framework.ITaskItem")
+    $filesParam = $parameterGroup.AddParameter("Files", "false", "true", "Microsoft.Build.Framework.ITaskItem[]")
+	$taskBody = $usingTask.AddUsingTaskBody("true", "<Reference xmlns=`"http://schemas.microsoft.com/developer/msbuild/2003`" Include=`"System.Xml`"/>
+      <Reference xmlns=`"http://schemas.microsoft.com/developer/msbuild/2003`" Include=`"System.Xml.Linq`"/>
+      <Using xmlns=`"http://schemas.microsoft.com/developer/msbuild/2003`" Namespace=`"System`"/>
+      <Using xmlns=`"http://schemas.microsoft.com/developer/msbuild/2003`" Namespace=`"System.IO`"/>
+      <Using xmlns=`"http://schemas.microsoft.com/developer/msbuild/2003`" Namespace=`"System.Xml.Linq`"/>
+      <Code xmlns=`"http://schemas.microsoft.com/developer/msbuild/2003`" Type=`"Fragment`" Language=`"cs`">
+<![CDATA[
+var config = XElement.Load(Config.ItemSpec).Elements(`"Costura`").FirstOrDefault();
+
+if (config == null) return true;
+
+var excludedAssemblies = new List<string>();
+var attribute = config.Attribute(`"ExcludeAssemblies`");
+if (attribute != null)
+    foreach (var item in attribute.Value.Split('|').Select(x => x.Trim()).Where(x => x != string.Empty))
+        excludedAssemblies.Add(item);
+var element = config.Element(`"ExcludeAssemblies`");
+if (element != null)
+    foreach (var item in element.Value.Split(new[] { `"\r\n`", `"\n`" }, StringSplitOptions.RemoveEmptyEntries).Select(x => x.Trim()).Where(x => x != string.Empty))
+        excludedAssemblies.Add(item);
+
+var filesToCleanup = Files.Select(f => f.ItemSpec).Where(f => !excludedAssemblies.Contains(Path.GetFileNameWithoutExtension(f), StringComparer.InvariantCultureIgnoreCase));
+
+foreach (var item in filesToCleanup)
+  File.Delete(item);
+]]>
+      </Code>")
+
+    $target = $buildProject.Xml.AddTarget("CleanReferenceCopyLocalPaths")
+    $target.AfterTargets = "AfterBuild;NonWinFodyTarget"
+    $deleteTask = $target.AddTask("CosturaCleanup")
+    $deleteTask.SetParameter("Config", "FodyWeavers.xml")
+    $deleteTask.SetParameter("Files", "@(ReferenceCopyLocalPaths->`'`$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)`')")
+
+    $buildProject.Save()
+
+    Write-Host "Added target CleanReferenceCopyLocalPaths."
+}
+
+function Uninstall-CleanReferencesTarget()
+{
+    $buildProject = Get-MSBuildProject
+
+    $target = $buildProject.Xml.Targets | Where-Object { "CleanReferenceCopyLocalPaths" -contains $_.Name }
+    $usingTask = $buildProject.Xml.UsingTasks | Where-Object { "CosturaCleanup" -contains $_.TaskName }
+
+    if (!$target)
+    {
+        Write-Host "Target CleanReferenceCopyLocalPaths did not exist." -foregroundcolor Black -backgroundcolor Yellow
+
+        return
+    }
+
+    $buildProject.Xml.RemoveChild($usingTask)
+    $buildProject.Xml.RemoveChild($target)
+
+    $buildProject.Save()
+
+    Write-Host "Removed target CleanReferenceCopyLocalPaths."
+}

--- a/src/BuildNuGetPackage/Assets/init.ps1
+++ b/src/BuildNuGetPackage/Assets/init.ps1
@@ -1,0 +1,3 @@
+﻿param($installPath, $toolsPath, $package, $project)
+
+Import-Module (Join-Path $toolsPath commands.psm1)

--- a/src/BuildNuGetPackage/BuildNuGetPackage.csproj
+++ b/src/BuildNuGetPackage/BuildNuGetPackage.csproj
@@ -48,8 +48,14 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="Assets\commands.psm1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Assets\Costura.Fody.nuspec">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Assets\init.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Assets\uninstall.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/BuildNuGetPackage/Program.cs
+++ b/src/BuildNuGetPackage/Program.cs
@@ -54,6 +54,8 @@ namespace BuildNuGetPackage
             });
 
             packageBuilder.PopulateFiles("Assets", new[] {
+                new ManifestFile { Source = "commands.psm1", Target = "tools" },
+                new ManifestFile { Source = "init.ps1", Target = "tools" },
                 new ManifestFile { Source = "install.ps1", Target = "tools" },
                 new ManifestFile { Source = "uninstall.ps1", Target = "tools" }
             });


### PR DESCRIPTION
The Install-CleanReferencesTarget cmdlet is pretty handy and is still referenced on the Readme.md
This reintroduces it. 

I'm not sure if the previous release was hand made but the required powershell scripts are not in the GitHub repo.