### PR TITLE
Ensure unit tests can run without running Visual Studio as admin

### DIFF
--- a/src/Costura.Tests/BaseCostura.cs
+++ b/src/Costura.Tests/BaseCostura.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Xml.Linq;
 using Mono.Cecil;
 using Mono.Cecil.Pdb;
+using System;
 
 public abstract class BaseCostura
 {
@@ -50,16 +51,29 @@ public abstract class BaseCostura
         };
         moduleDefinition.Write(afterAssemblyPath, writerParams);
 
-        Directory.CreateDirectory(Suffix);
-        var isolatedPath = Path.GetFullPath(Path.Combine(Suffix, $"Costura{Suffix}{extension}"));
+        var isolatedDirectory = GetIsolatedDirectory();
+        if (Directory.Exists(isolatedDirectory))
+        {
+            Directory.Delete(isolatedDirectory, true);
+        }
+        Directory.CreateDirectory(isolatedDirectory);
+        var isolatedPath = GetIsolatedFilePath(extension);
         File.Copy(afterAssemblyPath, isolatedPath, true);
         File.Copy(afterAssemblyPath.Replace(extension, ".pdb"), isolatedPath.Replace(extension, ".pdb"), true);
     }
 
+    private string GetIsolatedDirectory()
+    {
+        return Path.Combine(Path.GetTempPath(), $"Costura{Suffix}");
+    }
+
+    private string GetIsolatedFilePath(string extension)
+    {
+        return Path.GetFullPath(Path.Combine(GetIsolatedDirectory(), $"Costura{Suffix}{extension}"));
+    }
+
     protected void LoadAssemblyIntoAppDomain(string extension = ".exe")
     {
-        var isolatedPath = Path.GetFullPath(Path.Combine(Suffix, $"Costura{Suffix}{extension}"));
-
-        assembly = Assembly.LoadFile(isolatedPath);
+        assembly = Assembly.LoadFile(GetIsolatedFilePath(extension));
     }
 }

--- a/src/Costura.Tests/Costura.Tests.csproj
+++ b/src/Costura.Tests/Costura.Tests.csproj
@@ -98,6 +98,9 @@
     <Compile Include="TempFileTests.cs" />
     <Compile Include="Verifier.cs" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Costura.Tests/Costura.Tests.csproj
+++ b/src/Costura.Tests/Costura.Tests.csproj
@@ -98,15 +98,5 @@
     <Compile Include="TempFileTests.cs" />
     <Compile Include="Verifier.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>


### PR DESCRIPTION
When writing test target assemblies, use the temp folder instead of the current directory, since that defaults to the Visual Studio IDE folder under Program Files when running the tests using the NUnit Test Runner inside Visual Studio, to ensure that units tests can be run without having to run Visual Studio as an administrator.  Note that Visual Studio 2017 also automatically added a service guid to the test csproj which is to help identify it as a test project I believe.