### PR TITLE
Fix check for AssemblyNameFlags.Retargetable flag in ILTemplate

### DIFF
--- a/src/Costura.Template/ILTemplate.cs
+++ b/src/Costura.Template/ILTemplate.cs
@@ -53,7 +53,7 @@ static class ILTemplate
             }
 
             // Handles retargeted assemblies like PCL
-            if (requestedAssemblyName.Flags == AssemblyNameFlags.Retargetable)
+            if ((requestedAssemblyName.Flags & AssemblyNameFlags.Retargetable) != 0)
             {
                 assembly = Assembly.Load(requestedAssemblyName);
             }

--- a/src/Costura.Template/ILTemplateWithTempAssembly.cs
+++ b/src/Costura.Template/ILTemplateWithTempAssembly.cs
@@ -71,7 +71,7 @@ static class ILTemplateWithTempAssembly
             }
 
             // Handles retargeted assemblies like PCL
-            if (requestedAssemblyName.Flags == AssemblyNameFlags.Retargetable)
+            if ((requestedAssemblyName.Flags & AssemblyNameFlags.Retargetable) != 0)
             {
                 assembly = Assembly.Load(requestedAssemblyName);
             }

--- a/src/Costura.Template/ILTemplateWithUnmanagedHandler.cs
+++ b/src/Costura.Template/ILTemplateWithUnmanagedHandler.cs
@@ -76,7 +76,7 @@ static class ILTemplateWithUnmanagedHandler
             }
 
             // Handles retargeted assemblies like PCL
-            if (requestedAssemblyName.Flags == AssemblyNameFlags.Retargetable)
+            if ((requestedAssemblyName.Flags & AssemblyNameFlags.Retargetable) != 0)
             {
                 assembly = Assembly.Load(requestedAssemblyName);
             }


### PR DESCRIPTION
The enums of type `AssemblyNameFlags.Retargetable` allows for multiple values/flags and the check was expecting a single value, which is not always the case.