### PR TITLE
 #240: Cleanup interferes with installers

### DIFF
--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -14,11 +14,6 @@ using System.Threading;
 
 static class Common
 {
-    private const int DelayUntilReboot = 4;
-
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    static extern bool MoveFileEx(string lpExistingFileName, string lpNewFileName, int dwFlags);
-
     [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
     static extern IntPtr LoadLibrary(string dllToLoad);
 
@@ -249,10 +244,6 @@ static class Common
                 using (var assemblyTempFile = File.OpenWrite(assemblyTempFilePath))
                 {
                     CopyTo(copyStream, assemblyTempFile);
-                }
-                if (!MoveFileEx(assemblyTempFilePath, null, DelayUntilReboot))
-                {
-                    //TODO: for now we ignore the return value.
                 }
             }
         }


### PR DESCRIPTION
MoveFileEx(DelayUntilReboot) is not suitable to do cleanup in user code.
As discussed in #240, it rarely does something, and if it does something, it's more disrupting than helpful. 