### PR TITLE
Prevent error message when loading DLLs with unmet dependencies

### DIFF
--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -14,8 +14,6 @@ using System.Threading;
 
 static class Common
 {
-    private const int DelayUntilReboot = 4;
-
     [Flags]
     public enum ErrorModes : uint
     {
@@ -28,9 +26,6 @@ static class Common
 
     [DllImport("kernel32.dll")]
     static extern ErrorModes SetErrorMode(ErrorModes uMode);
-
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    static extern bool MoveFileEx(string lpExistingFileName, string lpNewFileName, int dwFlags);
 
     [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
     static extern IntPtr LoadLibrary(string dllToLoad);
@@ -262,10 +257,6 @@ static class Common
                 using (var assemblyTempFile = File.OpenWrite(assemblyTempFilePath))
                 {
                     CopyTo(copyStream, assemblyTempFile);
-                }
-                if (!MoveFileEx(assemblyTempFilePath, null, DelayUntilReboot))
-                {
-                    //TODO: for now we ignore the return value.
                 }
             }
         }

--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -278,7 +278,9 @@ static class Common
         // SEM_FAILCRITICALERRORS - The system does not display the critical-error-handler message box. Instead, the system sends the error to the calling process.
         // SEM_NOGPFAULTERRORBOX  - The system does not display the Windows Error Reporting dialog.
         // SEM_NOOPENFILEERRORBOX - The OpenFile function does not display a message box when it fails to find a file. Instead, the error is returned to the caller. 
-        SetErrorMode(ErrorModes.SEM_FAILCRITICALERRORS | ErrorModes.SEM_NOGPFAULTERRORBOX | ErrorModes.SEM_NOOPENFILEERRORBOX);
+        //
+        // return value is the previous state of the error-mode bit flags.
+        var originalErrorMode = SetErrorMode(ErrorModes.SEM_FAILCRITICALERRORS | ErrorModes.SEM_NOGPFAULTERRORBOX | ErrorModes.SEM_NOOPENFILEERRORBOX);
 
         foreach (var lib in libs)
         {
@@ -292,8 +294,8 @@ static class Common
             }
         }
 
-        // reset to default behaviour
-        SetErrorMode(0);
+        // restore to previous state
+        SetErrorMode(originalErrorMode);
     }
 
     static string ResourceNameToPath(string lib)


### PR DESCRIPTION
As per issue https://github.com/Fody/Costura/issues/248