### PR TITLE
Throw exception instead of catch it

### DIFF
--- a/src/Costura.Tasks/FilterReferenceCopyLocalPaths.cs
+++ b/src/Costura.Tasks/FilterReferenceCopyLocalPaths.cs
@@ -8,6 +8,8 @@ using Microsoft.Build.Utilities;
 
 namespace Costura.Tasks
 {
+    using System;
+
     public class FilterReferenceCopyLocalPaths : Task
     {
         [Required]
@@ -101,9 +103,11 @@ namespace Costura.Tasks
 
                 return true;
             }
-            catch
+            catch (Exception e)
             {
-                return false;
+                Console.WriteLine(e);
+                throw new WeavingException($"Could not read '{"FodyWeavers.xml"}' because it has invalid xml. Message: '{e}'.");
+                //return false;
             }
         }
 

--- a/src/Costura.Tasks/FilterReferenceCopyLocalPaths.cs
+++ b/src/Costura.Tasks/FilterReferenceCopyLocalPaths.cs
@@ -105,9 +105,7 @@ namespace Costura.Tasks
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
-                throw new WeavingException($"Could not read '{"FodyWeavers.xml"}' because it has invalid xml. Message: '{e}'.");
-                //return false;
+                throw new WeavingException($"Execute Failed. Message: '{e}'.");
             }
         }
 


### PR DESCRIPTION
Throw exception instead of catch it. Exception info printed in [OutPut Window] will be useful for problem solving.
I use the exception info found the config file format errors and solved it.