### PR TITLE
Add wildcard and regex support.

### DIFF
--- a/Costura.Fody/ResourceEmbedder.cs
+++ b/Costura.Fody/ResourceEmbedder.cs
@@ -89,9 +89,12 @@ partial class ModuleWeaver : IDisposable
 
     bool CompareAssemblyName(string assemblyName, string matchText)
     {
-        if (matchText.EndsWith("*"))
+        // Check if it's a regex statement, if not, convert to one.
+        if (!matchText.StartsWith("^"))
         {
-            return assemblyName.StartsWith(matchText.TrimEnd('*'));
+            // Convert all .'s to escaped characters then replace wildcards with regex match-all's.
+            matchText = matchText.Replace(".", "\\.").Replace("*", "(.*)");
+            matchText = "^" + matchText + "$";
         }
 
         return Regex.IsMatch(assemblyName, matchText);

--- a/Costura.Fody/ResourceEmbedder.cs
+++ b/Costura.Fody/ResourceEmbedder.cs
@@ -87,8 +87,9 @@ partial class ModuleWeaver : IDisposable
         }
     }
 
-    bool CompareAssemblyName(string assemblyName, string matchText)
+    bool CompareAssemblyName(string matchText, string assemblyName)
     {
+
         // Check if it's a regex statement, if not, convert to one.
         if (!matchText.StartsWith("^"))
         {
@@ -114,7 +115,7 @@ partial class ModuleWeaver : IDisposable
                     config.Unmanaged32Assemblies.All(x => !CompareAssemblyName(x, assemblyName)) &&
                     config.Unmanaged64Assemblies.All(x => !CompareAssemblyName(x, assemblyName)))
                 {
-                    skippedAssemblies.Remove(assemblyName);
+                    skippedAssemblies.Remove(config.IncludeAssemblies.First(x => CompareAssemblyName(x, assemblyName)));
                     yield return file;
                 }
             }
@@ -131,7 +132,7 @@ partial class ModuleWeaver : IDisposable
                 foreach (var skippedAssembly in skippedAssemblies)
                 {
                     var fileName = (from splittedReference in splittedReferences
-                                    where CompareAssemblyName(skippedAssembly, splittedReference)
+                                    where string.Equals(Path.GetFileNameWithoutExtension(skippedAssembly), splittedReference, StringComparison.InvariantCulture)
                                     select splittedReference).FirstOrDefault();
                     if (string.IsNullOrEmpty(fileName))
                     {

--- a/Costura.Fody/ResourceEmbedder.cs
+++ b/Costura.Fody/ResourceEmbedder.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using Mono.Cecil;
-using System.Text.RegularExpressions;
 
 partial class ModuleWeaver : IDisposable
 {
@@ -89,16 +88,12 @@ partial class ModuleWeaver : IDisposable
 
     bool CompareAssemblyName(string matchText, string assemblyName)
     {
-
-        // Check if it's a regex statement, if not, convert to one.
-        if (!matchText.StartsWith("^"))
+        if (matchText.EndsWith("*") && matchText.Length > 1)
         {
-            // Convert all .'s to escaped characters then replace wildcards with regex match-all's.
-            matchText = matchText.Replace(".", "\\.").Replace("*", "(.*)");
-            matchText = "^" + matchText + "$";
+            return assemblyName.StartsWith(matchText.Substring(0, matchText.Length - 1));
         }
 
-        return Regex.IsMatch(assemblyName, matchText);
+        return matchText.Equals(assemblyName);
     }
 
     IEnumerable<string> GetFilteredReferences(IEnumerable<string> onlyBinaries, Configuration config)

--- a/IntegrationTests/FodyWeavers.xml
+++ b/IntegrationTests/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura IncludeAssemblies="TomsToolbox.Core|TomsToolbox.Desktop|TomsToolbox.ObservableCollections|TomsToolbox.Wpf|System.Windows.Interactivity" />
+  <Costura IncludeAssemblies="TomsToolbox.Core|^TomsToolbox\.Desktop$|TomsToolbox.*|System.Windows.Interactivity" />
 </Weavers>

--- a/IntegrationTests/FodyWeavers.xml
+++ b/IntegrationTests/FodyWeavers.xml
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura IncludeAssemblies="TomsToolbox.Core|^TomsToolbox\.Desktop$|TomsToolbox.*|System.Windows.Interactivity" />
+  <Costura IncludeAssemblies="TomsToolbox.Core|TomsToolbox.*|System.Windows.Interactivity" />
 </Weavers>

--- a/README.md
+++ b/README.md
@@ -156,6 +156,8 @@ Do not include `.exe` or `.dll` in the names.
 
 Can not be defined with `IncludeAssemblies`.
 
+Can use wildcards for partial assembly name matching. For example `System.*` will exclude all assemblies that start with `System.`. Wildcards may only be used at the end of an entry so for example, `System.*.Private.*` would not work.
+
 Can take two forms.
 
 As an element with items delimited by a newline.
@@ -184,6 +186,8 @@ Do not include `.exe` or `.dll` in the names.
 
 Can not be defined with `ExcludeAssemblies`.
 
+Can use wildcards at the end of the name for partial matching.
+
 Can take two forms. 
 
 As an element with items delimited by a newline.
@@ -211,6 +215,8 @@ Mixed-mode assemblies cannot be loaded the same way as managed assemblies.
 Therefore, to help Costura identify which assemblies are mixed-mode, and in what environment to load them in you should include their names in one or both of these lists.
 
 Do not include `.exe` or `.dll` in the names.
+
+Can use wildcards at the end of the name for partial matching.
 
 Can take two forms. 
 

--- a/Tests/WildcardTest.cs
+++ b/Tests/WildcardTest.cs
@@ -1,0 +1,21 @@
+﻿using System.Linq;
+using Xunit;
+
+public class WildcardTest
+{
+    [Fact]
+    public void WeavesWildcards()
+    {
+        var wildcardWeave = WeavingHelper.CreateIsolatedAssemblyCopy("ExeToProcess.exe",
+            "<Costura IncludeAssemblies=\"AssemblyToReference*\"/>",
+            new[] { "AssemblyToReference.dll", "AssemblyToReferenceMixed.dll"}, "WildcardWeave");
+
+        var referencedAssemblies = wildcardWeave.Assembly.GetReferencedAssemblies().Select(x => x.Name).ToList();
+        Assert.Contains("AssemblyToReference", referencedAssemblies);
+        Assert.Contains("AssemblyToReferencePreEmbedded", referencedAssemblies);
+
+        var instance = wildcardWeave.GetInstance("ClassToTest");
+        Assert.Equal("Hello", instance.Simple());
+        Assert.Equal("Hello", instance.SimplePreEmbed());
+    }
+}


### PR DESCRIPTION
#### Description

Adds basic wildcard support and regex support to Include/Exclude assemblies. 
This was requested in https://github.com/Fody/Costura/issues/239.

#### The solution

Check the string for * at the end, if so, use a .StartsWith() for the comparison, otherwise use Regex.IsMatch() since plain string matching as well as regex patterns will work with this.