### PR TITLE
Ensure AppContext.TargetFrameworkName is set in the module initializer

### DIFF
--- a/src/Costura.Fody.Tests/BasicTests.TemplateHasCorrectSymbols.ForScenario.TempFileTests.net.debug.approved.txt
+++ b/src/Costura.Fody.Tests/BasicTests.TemplateHasCorrectSymbols.ForScenario.TempFileTests.net.debug.approved.txt
@@ -1114,12 +1114,16 @@ IL_0096:  ret
 .method public hidebysig static void  Attach() cil managed
 {
 .maxstack  4
-.locals init (string V_0,
+.locals init (class [mscorlib]System.AppDomain V_0,
 string V_1,
-class [mscorlib]System.Collections.Generic.List`1<string> V_2,
+string V_2,
 class [mscorlib]System.Collections.Generic.List`1<string> V_3,
-class [mscorlib]System.AppDomain V_4,
-bool V_5)
+class [mscorlib]System.Collections.Generic.List`1<string> V_4,
+bool V_5,
+bool V_6,
+class [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute V_7,
+string V_8,
+bool V_9)
 IL_0000:  nop
 IL_0001:  ldsflda    int32 Costura.AssemblyLoader::isAttached
 IL_0006:  ldc.i4.1
@@ -1129,57 +1133,98 @@ IL_000c:  ldc.i4.1
 IL_000d:  ceq
 IL_000f:  stloc.s    V_5
 IL_0011:  ldloc.s    V_5
-IL_0013:  brfalse.s  IL_0018
+IL_0013:  brfalse.s  IL_001b
 IL_0015:  nop
-IL_0016:  br.s       IL_0096
-IL_0018:  ldstr      "[CHECKSUM]"
-IL_001d:  stloc.0
-IL_001e:  call       string [mscorlib]System.IO.Path::GetTempPath()
-IL_0023:  ldstr      "Costura"
-IL_0028:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_0016:  br         IL_00f8
+IL_001b:  call       class [mscorlib]System.AppDomain [mscorlib]System.AppDomain::get_CurrentDomain()
+IL_0020:  stloc.0
+IL_0021:  call       string [mscorlib]System.AppContext::get_TargetFrameworkName()
+IL_0026:  ldnull
+IL_0027:  ceq
+IL_0029:  stloc.s    V_6
+IL_002b:  ldloc.s    V_6
+IL_002d:  brfalse.s  IL_007e
+IL_002f:  nop
+IL_0030:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::GetCallingAssembly()
+IL_0035:  dup
+IL_0036:  brtrue.s   IL_003c
+IL_0038:  pop
+IL_0039:  ldnull
+IL_003a:  br.s       IL_004b
+IL_003c:  ldtoken    [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute
+IL_0041:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+IL_0046:  call       class [mscorlib]System.Attribute [mscorlib]System.Reflection.CustomAttributeExtensions::GetCustomAttribute(class [mscorlib]System.Reflection.Assembly,
+class [mscorlib]System.Type)
+IL_004b:  castclass  [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute
+IL_0050:  stloc.s    V_7
+IL_0052:  ldloc.s    V_7
+IL_0054:  brtrue.s   IL_0059
+IL_0056:  ldnull
+IL_0057:  br.s       IL_0060
+IL_0059:  ldloc.s    V_7
+IL_005b:  call       instance string [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute::get_FrameworkName()
+IL_0060:  stloc.s    V_8
+IL_0062:  ldloc.s    V_8
+IL_0064:  ldnull
+IL_0065:  cgt.un
+IL_0067:  stloc.s    V_9
+IL_0069:  ldloc.s    V_9
+IL_006b:  brfalse.s  IL_007d
+IL_006d:  nop
+IL_006e:  ldloc.0
+IL_006f:  ldstr      "TargetFrameworkName"
+IL_0074:  ldloc.s    V_8
+IL_0076:  callvirt   instance void [mscorlib]System.AppDomain::SetData(string,
+object)
+IL_007b:  nop
+IL_007c:  nop
+IL_007d:  nop
+IL_007e:  ldstr      "[CHECKSUM]"
+IL_0083:  stloc.1
+IL_0084:  call       string [mscorlib]System.IO.Path::GetTempPath()
+IL_0089:  ldstr      "Costura"
+IL_008e:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_002d:  stloc.1
-IL_002e:  ldloc.1
-IL_002f:  ldloc.0
-IL_0030:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_0093:  stloc.2
+IL_0094:  ldloc.2
+IL_0095:  ldloc.1
+IL_0096:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_0035:  stsfld     string Costura.AssemblyLoader::tempBasePath
-IL_003a:  call       int32 [mscorlib]System.IntPtr::get_Size()
-IL_003f:  ldc.i4.8
-IL_0040:  beq.s      IL_0049
-IL_0042:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload32List
-IL_0047:  br.s       IL_004e
-IL_0049:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload64List
-IL_004e:  stloc.2
-IL_004f:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<string>::.ctor()
-IL_0054:  stloc.3
-IL_0055:  ldloc.3
-IL_0056:  ldloc.2
-IL_0057:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<string>::AddRange(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-IL_005c:  nop
-IL_005d:  ldloc.3
-IL_005e:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preloadList
-IL_0063:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<string>::AddRange(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-IL_0068:  nop
-IL_0069:  ldloc.0
-IL_006a:  ldsfld     string Costura.AssemblyLoader::tempBasePath
-IL_006f:  ldloc.3
-IL_0070:  ldsfld     class [mscorlib]System.Collections.Generic.Dictionary`2<string,string> Costura.AssemblyLoader::checksums
-IL_0075:  call       void Costura.AssemblyLoader::PreloadUnmanagedLibraries(string,
+IL_009b:  stsfld     string Costura.AssemblyLoader::tempBasePath
+IL_00a0:  call       int32 [mscorlib]System.IntPtr::get_Size()
+IL_00a5:  ldc.i4.8
+IL_00a6:  beq.s      IL_00af
+IL_00a8:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload32List
+IL_00ad:  br.s       IL_00b4
+IL_00af:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload64List
+IL_00b4:  stloc.3
+IL_00b5:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<string>::.ctor()
+IL_00ba:  stloc.s    V_4
+IL_00bc:  ldloc.s    V_4
+IL_00be:  ldloc.3
+IL_00bf:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<string>::AddRange(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+IL_00c4:  nop
+IL_00c5:  ldloc.s    V_4
+IL_00c7:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preloadList
+IL_00cc:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<string>::AddRange(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+IL_00d1:  nop
+IL_00d2:  ldloc.1
+IL_00d3:  ldsfld     string Costura.AssemblyLoader::tempBasePath
+IL_00d8:  ldloc.s    V_4
+IL_00da:  ldsfld     class [mscorlib]System.Collections.Generic.Dictionary`2<string,string> Costura.AssemblyLoader::checksums
+IL_00df:  call       void Costura.AssemblyLoader::PreloadUnmanagedLibraries(string,
 string,
 class [mscorlib]System.Collections.Generic.List`1<string>,
 class [mscorlib]System.Collections.Generic.Dictionary`2<string,string>)
-IL_007a:  nop
-IL_007b:  call       class [mscorlib]System.AppDomain [mscorlib]System.AppDomain::get_CurrentDomain()
-IL_0080:  stloc.s    V_4
-IL_0082:  ldloc.s    V_4
-IL_0084:  ldnull
-IL_0085:  ldftn      class [mscorlib]System.Reflection.Assembly Costura.AssemblyLoader::ResolveAssembly(object,
+IL_00e4:  nop
+IL_00e5:  ldloc.0
+IL_00e6:  ldnull
+IL_00e7:  ldftn      class [mscorlib]System.Reflection.Assembly Costura.AssemblyLoader::ResolveAssembly(object,
 class [mscorlib]System.ResolveEventArgs)
-IL_008b:  newobj     instance void [mscorlib]System.ResolveEventHandler::.ctor(object,
+IL_00ed:  newobj     instance void [mscorlib]System.ResolveEventHandler::.ctor(object,
 native int)
-IL_0090:  callvirt   instance void [mscorlib]System.AppDomain::add_AssemblyResolve(class [mscorlib]System.ResolveEventHandler)
-IL_0095:  nop
-IL_0096:  ret
+IL_00f2:  callvirt   instance void [mscorlib]System.AppDomain::add_AssemblyResolve(class [mscorlib]System.ResolveEventHandler)
+IL_00f7:  nop
+IL_00f8:  ret
 }
 }

--- a/src/Costura.Fody.Tests/BasicTests.TemplateHasCorrectSymbols.ForScenario.TempFileTests.net.release.approved.txt
+++ b/src/Costura.Fody.Tests/BasicTests.TemplateHasCorrectSymbols.ForScenario.TempFileTests.net.release.approved.txt
@@ -862,11 +862,13 @@ IL_0077:  ret
 .method public hidebysig static void  Attach() cil managed
 {
 .maxstack  4
-.locals init (string V_0,
+.locals init (class [mscorlib]System.AppDomain V_0,
 string V_1,
-class [mscorlib]System.Collections.Generic.List`1<string> V_2,
+string V_2,
 class [mscorlib]System.Collections.Generic.List`1<string> V_3,
-class [mscorlib]System.AppDomain V_4)
+class [mscorlib]System.Collections.Generic.List`1<string> V_4,
+class [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute V_5,
+string V_6)
 IL_0000:  ldsflda    int32 Costura.AssemblyLoader::isAttached
 IL_0005:  ldc.i4.1
 IL_0006:  call       int32 [mscorlib]System.Threading.Interlocked::Exchange(int32&,
@@ -874,50 +876,78 @@ int32)
 IL_000b:  ldc.i4.1
 IL_000c:  bne.un.s   IL_000f
 IL_000e:  ret
-IL_000f:  ldstr      "[CHECKSUM]"
+IL_000f:  call       class [mscorlib]System.AppDomain [mscorlib]System.AppDomain::get_CurrentDomain()
 IL_0014:  stloc.0
-IL_0015:  call       string [mscorlib]System.IO.Path::GetTempPath()
-IL_001a:  ldstr      "Costura"
-IL_001f:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_0015:  call       string [mscorlib]System.AppContext::get_TargetFrameworkName()
+IL_001a:  brtrue.s   IL_005f
+IL_001c:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::GetCallingAssembly()
+IL_0021:  dup
+IL_0022:  brtrue.s   IL_0028
+IL_0024:  pop
+IL_0025:  ldnull
+IL_0026:  br.s       IL_0037
+IL_0028:  ldtoken    [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute
+IL_002d:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+IL_0032:  call       class [mscorlib]System.Attribute [mscorlib]System.Reflection.CustomAttributeExtensions::GetCustomAttribute(class [mscorlib]System.Reflection.Assembly,
+class [mscorlib]System.Type)
+IL_0037:  castclass  [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute
+IL_003c:  stloc.s    V_5
+IL_003e:  ldloc.s    V_5
+IL_0040:  brtrue.s   IL_0045
+IL_0042:  ldnull
+IL_0043:  br.s       IL_004c
+IL_0045:  ldloc.s    V_5
+IL_0047:  call       instance string [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute::get_FrameworkName()
+IL_004c:  stloc.s    V_6
+IL_004e:  ldloc.s    V_6
+IL_0050:  brfalse.s  IL_005f
+IL_0052:  ldloc.0
+IL_0053:  ldstr      "TargetFrameworkName"
+IL_0058:  ldloc.s    V_6
+IL_005a:  callvirt   instance void [mscorlib]System.AppDomain::SetData(string,
+object)
+IL_005f:  ldstr      "[CHECKSUM]"
+IL_0064:  stloc.1
+IL_0065:  call       string [mscorlib]System.IO.Path::GetTempPath()
+IL_006a:  ldstr      "Costura"
+IL_006f:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_0024:  stloc.1
-IL_0025:  ldloc.1
-IL_0026:  ldloc.0
-IL_0027:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_0074:  stloc.2
+IL_0075:  ldloc.2
+IL_0076:  ldloc.1
+IL_0077:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_002c:  stsfld     string Costura.AssemblyLoader::tempBasePath
-IL_0031:  call       int32 [mscorlib]System.IntPtr::get_Size()
-IL_0036:  ldc.i4.8
-IL_0037:  beq.s      IL_0040
-IL_0039:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload32List
-IL_003e:  br.s       IL_0045
-IL_0040:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload64List
-IL_0045:  stloc.2
-IL_0046:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<string>::.ctor()
-IL_004b:  stloc.3
-IL_004c:  ldloc.3
-IL_004d:  ldloc.2
-IL_004e:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<string>::AddRange(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-IL_0053:  ldloc.3
-IL_0054:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preloadList
-IL_0059:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<string>::AddRange(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
-IL_005e:  ldloc.0
-IL_005f:  ldsfld     string Costura.AssemblyLoader::tempBasePath
-IL_0064:  ldloc.3
-IL_0065:  ldsfld     class [mscorlib]System.Collections.Generic.Dictionary`2<string,string> Costura.AssemblyLoader::checksums
-IL_006a:  call       void Costura.AssemblyLoader::PreloadUnmanagedLibraries(string,
+IL_007c:  stsfld     string Costura.AssemblyLoader::tempBasePath
+IL_0081:  call       int32 [mscorlib]System.IntPtr::get_Size()
+IL_0086:  ldc.i4.8
+IL_0087:  beq.s      IL_0090
+IL_0089:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload32List
+IL_008e:  br.s       IL_0095
+IL_0090:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload64List
+IL_0095:  stloc.3
+IL_0096:  newobj     instance void class [mscorlib]System.Collections.Generic.List`1<string>::.ctor()
+IL_009b:  stloc.s    V_4
+IL_009d:  ldloc.s    V_4
+IL_009f:  ldloc.3
+IL_00a0:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<string>::AddRange(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+IL_00a5:  ldloc.s    V_4
+IL_00a7:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preloadList
+IL_00ac:  callvirt   instance void class [mscorlib]System.Collections.Generic.List`1<string>::AddRange(class [mscorlib]System.Collections.Generic.IEnumerable`1<!0>)
+IL_00b1:  ldloc.1
+IL_00b2:  ldsfld     string Costura.AssemblyLoader::tempBasePath
+IL_00b7:  ldloc.s    V_4
+IL_00b9:  ldsfld     class [mscorlib]System.Collections.Generic.Dictionary`2<string,string> Costura.AssemblyLoader::checksums
+IL_00be:  call       void Costura.AssemblyLoader::PreloadUnmanagedLibraries(string,
 string,
 class [mscorlib]System.Collections.Generic.List`1<string>,
 class [mscorlib]System.Collections.Generic.Dictionary`2<string,string>)
-IL_006f:  call       class [mscorlib]System.AppDomain [mscorlib]System.AppDomain::get_CurrentDomain()
-IL_0074:  stloc.s    V_4
-IL_0076:  ldloc.s    V_4
-IL_0078:  ldnull
-IL_0079:  ldftn      class [mscorlib]System.Reflection.Assembly Costura.AssemblyLoader::ResolveAssembly(object,
+IL_00c3:  ldloc.0
+IL_00c4:  ldnull
+IL_00c5:  ldftn      class [mscorlib]System.Reflection.Assembly Costura.AssemblyLoader::ResolveAssembly(object,
 class [mscorlib]System.ResolveEventArgs)
-IL_007f:  newobj     instance void [mscorlib]System.ResolveEventHandler::.ctor(object,
+IL_00cb:  newobj     instance void [mscorlib]System.ResolveEventHandler::.ctor(object,
 native int)
-IL_0084:  callvirt   instance void [mscorlib]System.AppDomain::add_AssemblyResolve(class [mscorlib]System.ResolveEventHandler)
-IL_0089:  ret
+IL_00d0:  callvirt   instance void [mscorlib]System.AppDomain::add_AssemblyResolve(class [mscorlib]System.ResolveEventHandler)
+IL_00d5:  ret
 }
 }

--- a/src/Costura.Fody.Tests/Helpers/RunHelper.cs
+++ b/src/Costura.Fody.Tests/Helpers/RunHelper.cs
@@ -1,0 +1,18 @@
+﻿using System.Diagnostics;
+
+internal static class RunHelper
+{
+    public static string RunExecutable(string executablePath)
+    {
+        var startInfo = new ProcessStartInfo(executablePath)
+        {
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+        };
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+        process.WaitForExit();
+        return process.StandardOutput.ReadToEnd();
+    }
+}

--- a/src/Costura.Fody.Tests/InMemoryTests.cs
+++ b/src/Costura.Fody.Tests/InMemoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using Fody;
+using NUnit.Framework;
 
 public class InMemoryTests : BasicTests
 {
@@ -9,6 +10,13 @@ public class InMemoryTests : BasicTests
         testResult = WeavingHelper.CreateIsolatedAssemblyCopy("ExeToProcess.exe",
             "<Costura />",
             new[] {"AssemblyToReference.dll", "AssemblyToReferencePreEmbedded.dll", "ExeToReference.exe"}, "InMemory");
+    }
+
+    [Test]
+    public void ExecutableRunsSuccessfully()
+    {
+        var output = RunHelper.RunExecutable(TestResult.AssemblyPath);
+        Assert.AreEqual("Run-OK", output);
     }
 
     public override TestResult TestResult => testResult;

--- a/src/Costura.Fody.Tests/MixedAndNativeTests.TemplateHasCorrectSymbols.ForScenario.MixedAndNativeTests.net.debug.approved.txt
+++ b/src/Costura.Fody.Tests/MixedAndNativeTests.TemplateHasCorrectSymbols.ForScenario.MixedAndNativeTests.net.debug.approved.txt
@@ -1287,11 +1287,15 @@ IL_0096:  ret
 .method public hidebysig static void  Attach() cil managed
 {
 .maxstack  4
-.locals init (string V_0,
+.locals init (class [mscorlib]System.AppDomain V_0,
 string V_1,
-class [mscorlib]System.Collections.Generic.List`1<string> V_2,
-class [mscorlib]System.AppDomain V_3,
-bool V_4)
+string V_2,
+class [mscorlib]System.Collections.Generic.List`1<string> V_3,
+bool V_4,
+bool V_5,
+class [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute V_6,
+string V_7,
+bool V_8)
 IL_0000:  nop
 IL_0001:  ldsflda    int32 Costura.AssemblyLoader::isAttached
 IL_0006:  ldc.i4.1
@@ -1301,47 +1305,88 @@ IL_000c:  ldc.i4.1
 IL_000d:  ceq
 IL_000f:  stloc.s    V_4
 IL_0011:  ldloc.s    V_4
-IL_0013:  brfalse.s  IL_0018
+IL_0013:  brfalse.s  IL_001b
 IL_0015:  nop
-IL_0016:  br.s       IL_007a
-IL_0018:  ldstr      "[CHECKSUM]"
-IL_001d:  stloc.0
-IL_001e:  call       string [mscorlib]System.IO.Path::GetTempPath()
-IL_0023:  ldstr      "Costura"
-IL_0028:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_0016:  br         IL_00da
+IL_001b:  call       class [mscorlib]System.AppDomain [mscorlib]System.AppDomain::get_CurrentDomain()
+IL_0020:  stloc.0
+IL_0021:  call       string [mscorlib]System.AppContext::get_TargetFrameworkName()
+IL_0026:  ldnull
+IL_0027:  ceq
+IL_0029:  stloc.s    V_5
+IL_002b:  ldloc.s    V_5
+IL_002d:  brfalse.s  IL_007e
+IL_002f:  nop
+IL_0030:  call       class [mscorlib]System.Reflection.Assembly [mscorlib]System.Reflection.Assembly::GetCallingAssembly()
+IL_0035:  dup
+IL_0036:  brtrue.s   IL_003c
+IL_0038:  pop
+IL_0039:  ldnull
+IL_003a:  br.s       IL_004b
+IL_003c:  ldtoken    [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute
+IL_0041:  call       class [mscorlib]System.Type [mscorlib]System.Type::GetTypeFromHandle(valuetype [mscorlib]System.RuntimeTypeHandle)
+IL_0046:  call       class [mscorlib]System.Attribute [mscorlib]System.Reflection.CustomAttributeExtensions::GetCustomAttribute(class [mscorlib]System.Reflection.Assembly,
+class [mscorlib]System.Type)
+IL_004b:  castclass  [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute
+IL_0050:  stloc.s    V_6
+IL_0052:  ldloc.s    V_6
+IL_0054:  brtrue.s   IL_0059
+IL_0056:  ldnull
+IL_0057:  br.s       IL_0060
+IL_0059:  ldloc.s    V_6
+IL_005b:  call       instance string [mscorlib]System.Runtime.Versioning.TargetFrameworkAttribute::get_FrameworkName()
+IL_0060:  stloc.s    V_7
+IL_0062:  ldloc.s    V_7
+IL_0064:  ldnull
+IL_0065:  cgt.un
+IL_0067:  stloc.s    V_8
+IL_0069:  ldloc.s    V_8
+IL_006b:  brfalse.s  IL_007d
+IL_006d:  nop
+IL_006e:  ldloc.0
+IL_006f:  ldstr      "TargetFrameworkName"
+IL_0074:  ldloc.s    V_7
+IL_0076:  callvirt   instance void [mscorlib]System.AppDomain::SetData(string,
+object)
+IL_007b:  nop
+IL_007c:  nop
+IL_007d:  nop
+IL_007e:  ldstr      "[CHECKSUM]"
+IL_0083:  stloc.1
+IL_0084:  call       string [mscorlib]System.IO.Path::GetTempPath()
+IL_0089:  ldstr      "Costura"
+IL_008e:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_002d:  stloc.1
-IL_002e:  ldloc.1
-IL_002f:  ldloc.0
-IL_0030:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_0093:  stloc.2
+IL_0094:  ldloc.2
+IL_0095:  ldloc.1
+IL_0096:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_0035:  stsfld     string Costura.AssemblyLoader::tempBasePath
-IL_003a:  call       int32 [mscorlib]System.IntPtr::get_Size()
-IL_003f:  ldc.i4.8
-IL_0040:  beq.s      IL_0049
-IL_0042:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload32List
-IL_0047:  br.s       IL_004e
-IL_0049:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload64List
-IL_004e:  stloc.2
-IL_004f:  ldloc.0
-IL_0050:  ldsfld     string Costura.AssemblyLoader::tempBasePath
-IL_0055:  ldloc.2
-IL_0056:  ldsfld     class [mscorlib]System.Collections.Generic.Dictionary`2<string,string> Costura.AssemblyLoader::checksums
-IL_005b:  call       void Costura.AssemblyLoader::PreloadUnmanagedLibraries(string,
+IL_009b:  stsfld     string Costura.AssemblyLoader::tempBasePath
+IL_00a0:  call       int32 [mscorlib]System.IntPtr::get_Size()
+IL_00a5:  ldc.i4.8
+IL_00a6:  beq.s      IL_00af
+IL_00a8:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload32List
+IL_00ad:  br.s       IL_00b4
+IL_00af:  ldsfld     class [mscorlib]System.Collections.Generic.List`1<string> Costura.AssemblyLoader::preload64List
+IL_00b4:  stloc.3
+IL_00b5:  ldloc.1
+IL_00b6:  ldsfld     string Costura.AssemblyLoader::tempBasePath
+IL_00bb:  ldloc.3
+IL_00bc:  ldsfld     class [mscorlib]System.Collections.Generic.Dictionary`2<string,string> Costura.AssemblyLoader::checksums
+IL_00c1:  call       void Costura.AssemblyLoader::PreloadUnmanagedLibraries(string,
 string,
 class [mscorlib]System.Collections.Generic.List`1<string>,
 class [mscorlib]System.Collections.Generic.Dictionary`2<string,string>)
-IL_0060:  nop
-IL_0061:  call       class [mscorlib]System.AppDomain [mscorlib]System.AppDomain::get_CurrentDomain()
-IL_0066:  stloc.3
-IL_0067:  ldloc.3
-IL_0068:  ldnull
-IL_0069:  ldftn      class [mscorlib]System.Reflection.Assembly Costura.AssemblyLoader::ResolveAssembly(object,
+IL_00c6:  nop
+IL_00c7:  ldloc.0
+IL_00c8:  ldnull
+IL_00c9:  ldftn      class [mscorlib]System.Reflection.Assembly Costura.AssemblyLoader::ResolveAssembly(object,
 class [mscorlib]System.ResolveEventArgs)
-IL_006f:  newobj     instance void [mscorlib]System.ResolveEventHandler::.ctor(object,
+IL_00cf:  newobj     instance void [mscorlib]System.ResolveEventHandler::.ctor(object,
 native int)
-IL_0074:  callvirt   instance void [mscorlib]System.AppDomain::add_AssemblyResolve(class [mscorlib]System.ResolveEventHandler)
-IL_0079:  nop
-IL_007a:  ret
+IL_00d4:  callvirt   instance void [mscorlib]System.AppDomain::add_AssemblyResolve(class [mscorlib]System.ResolveEventHandler)
+IL_00d9:  nop
+IL_00da:  ret
 }
 }

--- a/src/Costura.Fody.Tests/MixedAndNativeTests.cs
+++ b/src/Costura.Fody.Tests/MixedAndNativeTests.cs
@@ -43,4 +43,11 @@ public class MixedAndNativeTests : BaseCosturaTest
             Approvals.Verify(text);
         }
     }
+
+    [Test]
+    public void ExecutableRunsSuccessfully()
+    {
+        var output = RunHelper.RunExecutable(TestResult.AssemblyPath);
+        Assert.AreEqual("Run-OK", output);
+    }
 }

--- a/src/Costura.Fody.Tests/MixedAndNativeTestsWithEmbeddedMixed.cs
+++ b/src/Costura.Fody.Tests/MixedAndNativeTestsWithEmbeddedMixed.cs
@@ -29,4 +29,11 @@ public class MixedAndNativeTestsWithEmbeddedMixed : BaseCosturaTest
         var instance1 = TestResult.GetInstance("ClassToTest");
         Assert.AreEqual("Hello", instance1.MixedFooPInvoke());
     }
+
+    [Test]
+    public void ExecutableRunsSuccessfully()
+    {
+        var output = RunHelper.RunExecutable(TestResult.AssemblyPath);
+        Assert.AreEqual("Run-OK", output);
+    }
 }

--- a/src/Costura.Fody.Tests/TempFileTests.cs
+++ b/src/Costura.Fody.Tests/TempFileTests.cs
@@ -1,4 +1,5 @@
 ﻿using Fody;
+using NUnit.Framework;
 
 public class TempFileTests : BasicTests
 {
@@ -10,5 +11,12 @@ public class TempFileTests : BasicTests
         testResult = WeavingHelper.CreateIsolatedAssemblyCopy("ExeToProcess.exe",
             "<Costura CreateTemporaryAssemblies='true' />",
             new[] {"AssemblyToReference.dll", "AssemblyToReferencePreEmbedded.dll", "ExeToReference.exe"}, "TempFile");
+    }
+
+    [Test]
+    public void ExecutableRunsSuccessfully()
+    {
+        var output = RunHelper.RunExecutable(TestResult.AssemblyPath);
+        Assert.AreEqual("Run-OK", output);
     }
 }

--- a/src/Costura.Template/ILTemplateWithUnmanagedHandler.cs
+++ b/src/Costura.Template/ILTemplateWithUnmanagedHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Versioning;
 using System.Threading;
 
 internal static class ILTemplateWithUnmanagedHandler
@@ -28,6 +29,20 @@ internal static class ILTemplateWithUnmanagedHandler
             return;
         }
 
+        var currentDomain = AppDomain.CurrentDomain;
+
+        // Make sure the target framework is set in order not to interfere with AppContext switches initialization
+        // See https://github.com/Fody/Costura/issues/633 for full explanation
+        if (AppContext.TargetFrameworkName == null)
+        {
+            var targetFrameworkAttribute = (TargetFrameworkAttribute)Assembly.GetCallingAssembly()?.GetCustomAttribute(typeof(TargetFrameworkAttribute));
+            var targetFrameworkName = targetFrameworkAttribute?.FrameworkName;
+            if (targetFrameworkName != null)
+            {
+                currentDomain.SetData(nameof(AppContext.TargetFrameworkName), targetFrameworkName);
+            }
+        }
+
         //Create a unique Temp directory for the application path.
         var md5Hash = "To be replaced at compile time";
         var prefixPath = Path.Combine(Path.GetTempPath(), "Costura");
@@ -37,7 +52,6 @@ internal static class ILTemplateWithUnmanagedHandler
         var unmanagedAssemblies = IntPtr.Size == 8 ? preload64List : preload32List;
         Common.PreloadUnmanagedLibraries(md5Hash, tempBasePath, unmanagedAssemblies, checksums);
 
-        var currentDomain = AppDomain.CurrentDomain;
         currentDomain.AssemblyResolve += ResolveAssembly;
     }
 

--- a/src/ExeToProcess/Program.cs
+++ b/src/ExeToProcess/Program.cs
@@ -1,6 +1,15 @@
-﻿class Program
+﻿using System;
+
+class Program
 {
     static void Main()
     {
+        // When the AppContext switches are properly initialized with the executable targeting ".NETFramework,Version=v4.7.2",
+        // the "Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces" is _not_ set at all.
+        // "Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces" is set to true if the AppContext switches are initialized with a wrong target framework name
+        // See https://github.com/Fody/Costura/issues/633 for more information
+        var appContextDefaultSwitchIsCorrect = AppContext.TryGetSwitch("Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces", out _) == false;
+        const string errorMessage = "Switch.System.Diagnostics.IgnorePortablePDBsInStackTraces should not be set for an executable targeting .NET Framework 4.7.2";
+        Console.Out.Write(appContextDefaultSwitchIsCorrect ? "Run-OK" : errorMessage);
     }
 }

--- a/src/ExeToProcessWithNative/ExeToProcessWithNative.csproj
+++ b/src/ExeToProcessWithNative/ExeToProcessWithNative.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Compile Include="..\ExeToProcess\Program.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\AssemblyToReferenceMixed\AssemblyToReferenceMixed.vcxproj" PrivateAssets="All" />
     <EmbeddedResource Include="$(OverridableOutputRootPath)\AssemblyToReferenceNative\AssemblyToReferenceNative.dll">
       <Link>costura32\AssemblyToReferenceNative.dll</Link>

--- a/src/ExeToProcessWithNative/Program.cs
+++ b/src/ExeToProcessWithNative/Program.cs
@@ -1,6 +1,0 @@
-﻿class Program
-{
-    static void Main()
-    {
-    }
-}

--- a/src/ExeToProcessWithNativeAndEmbeddedMixed/ExeToProcessWithNativeAndEmbeddedMixed.csproj
+++ b/src/ExeToProcessWithNativeAndEmbeddedMixed/ExeToProcessWithNativeAndEmbeddedMixed.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Compile Include="..\ExeToProcess\Program.cs" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\AssemblyToReferenceMixed\AssemblyToReferenceMixed.vcxproj"/>
   </ItemGroup>
   

--- a/src/ExeToProcessWithNativeAndEmbeddedMixed/Program.cs
+++ b/src/ExeToProcessWithNativeAndEmbeddedMixed/Program.cs
@@ -1,6 +1,0 @@
-﻿class Program
-{
-    static void Main()
-    {
-    }
-}


### PR DESCRIPTION
New tests were added that run the weaved executable files and ensure that Costura does not interfere with AppContext switches initialization.

Fixes #633