### PR TITLE
Fix the XML schema documentation about runtime assemblies

### DIFF
--- a/src/Costura.Fody/Costura.Fody.xcf
+++ b/src/Costura.Fody/Costura.Fody.xcf
@@ -13,12 +13,12 @@
     </xs:element>
     <xs:element  minOccurs="0" maxOccurs="1" name="ExcludeRuntimeAssemblies" type="xs:string">
       <xs:annotation>
-        <xs:documentation>A list of (.NET Core) runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with line breaks</xs:documentation>
+        <xs:documentation>A list of runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with line breaks</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element  minOccurs="0" maxOccurs="1" name="IncludeRuntimeAssemblies" type="xs:string">
       <xs:annotation>
-        <xs:documentation>A list of (.NET Core) runtime assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
+        <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with line breaks.</xs:documentation>
       </xs:annotation>
     </xs:element>
     <xs:element  minOccurs="0" maxOccurs="1" name="Unmanaged32Assemblies" type="xs:string">
@@ -49,7 +49,7 @@
   </xs:attribute>
   <xs:attribute name="IncludeRuntimeReferences" type="xs:boolean">
     <xs:annotation>
-      <xs:documentation>Controls if (.NET Core) runtime assemblies are also embedded.</xs:documentation>
+      <xs:documentation>Controls if runtime assemblies are also embedded.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="DisableCompression" type="xs:boolean">
@@ -84,12 +84,12 @@
   </xs:attribute>
   <xs:attribute name="ExcludeRuntimeAssemblies" type="xs:string">
     <xs:annotation>
-      <xs:documentation>A list of (.NET Core) runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with |</xs:documentation>
+      <xs:documentation>A list of runtime assembly names to exclude from the default action of "embed all Copy Local references", delimited with |</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="IncludeRuntimeAssemblies" type="xs:string">
     <xs:annotation>
-      <xs:documentation>A list of (.NET Core) runtime assembly names to include from the default action of "embed all Copy Local references", delimited with |.</xs:documentation>
+      <xs:documentation>A list of runtime assembly names to include from the default action of "embed all Copy Local references", delimited with |.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
   <xs:attribute name="Unmanaged32Assemblies" type="xs:string">


### PR DESCRIPTION
Should have been part of 0a5146577b798dba2c54eb680624badb5dc824e4