### PR TITLE
Add new UseRuntimeReferencePaths configuration setting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,21 @@ Controls whether the `runtimes` folder, used by .NET Core, for the embedded depe
 ```
 
 
+### UseRuntimeReferencePaths
+
+Controls whether the *runtime* assemblies are embedded with their full path or only with their assembly name.
+
+For example, the reference `system.text.encoding.codepages\5.0.0\runtimes\win\lib\net461\System.Text.Encoding.CodePages.dll` will be embedded as `costura.system.text.encoding.codepages.dll.compressed` when `false`, so Costura will automatically load it.
+
+It will be embedded as `costura.runtimes.win.lib.net461.system.text.encoding.codepages.dll.compressed` when `true` (given `IncludeRuntimeReferences='true'` and `IncludeRuntimeAssemblies='System.Text.Encoding.CodePages'`), requiring custom user code to load the embedded compressed assembly.
+
+*Defaults to `false` when the weaved assembly targets .NET Framework, `true` when the weaved assembly targets .NET Core*
+
+```xml
+<Costura UseRuntimeReferencePaths='true' />
+```
+
+
 ### DisableCompression
 
 Embedded assemblies are compressed by default, and uncompressed when they are loaded. You can turn compression off with this option.

--- a/src/Costura.Fody.Tests/ReferenceTests.cs
+++ b/src/Costura.Fody.Tests/ReferenceTests.cs
@@ -10,7 +10,17 @@
         [TestCase(@"C:\Source\Catel.Core\output\runtimes\win-x64\Catel.Core.dll", "runtimes/win-x64/Catel.Core.dll")]
         public void RelativePath(string input, string expectedOutput)
         {
-            var reference = new Reference(input);
+            var reference = new Reference(input, useRuntimeReferencePaths: true);
+
+            Assert.AreEqual(expectedOutput, reference.RelativeFileName);
+        }
+
+        [TestCase(@"C:\Source\Catel.Core\output\Catel.Core.dll", "Catel.Core.dll")]
+        [TestCase(@"C:\Source\Catel.Core\output\nl\Catel.Core.resources.dll", "nl/Catel.Core.resources.dll")]
+        [TestCase(@"C:\Source\Catel.Core\output\runtimes\win-x64\Catel.Core.dll", "Catel.Core.dll")]
+        public void RelativePath_UseNonRuntimeReferencePath(string input, string expectedOutput)
+        {
+            var reference = new Reference(input, useRuntimeReferencePaths: false);
 
             Assert.AreEqual(expectedOutput, reference.RelativeFileName);
         }
@@ -20,7 +30,17 @@
         [TestCase(@"C:\Source\Catel.Core\output\runtimes\win-x64\Catel.Core.dll", "runtimes.win-x64")]
         public void RelativePrefix(string input, string expectedOutput)
         {
-            var reference = new Reference(input);
+            var reference = new Reference(input, useRuntimeReferencePaths: true);
+
+            Assert.AreEqual(expectedOutput, reference.RelativePrefix);
+        }
+
+        [TestCase(@"C:\Source\Catel.Core\output\Catel.Core.dll", "")]
+        [TestCase(@"C:\Source\Catel.Core\output\nl\Catel.Core.resources.dll", "")]
+        [TestCase(@"C:\Source\Catel.Core\output\runtimes\win-x64\Catel.Core.dll", "")]
+        public void RelativePrefix_UseNonRuntimeReferencePath(string input, string expectedOutput)
+        {
+            var reference = new Reference(input, useRuntimeReferencePaths: false);
 
             Assert.AreEqual(expectedOutput, reference.RelativePrefix);
         }
@@ -30,7 +50,17 @@
         [TestCase(@"C:\Source\Catel.Core\output\runtimes\win-x64\Catel.Core.dll", true)]
         public void IsRuntimeReference(string input, bool expectedOutput)
         {
-            var reference = new Reference(input);
+            var reference = new Reference(input, useRuntimeReferencePaths: true);
+
+            Assert.AreEqual(expectedOutput, reference.IsRuntimeReference);
+        }
+
+        [TestCase(@"C:\Source\Catel.Core\output\Catel.Core.dll", false)]
+        [TestCase(@"C:\Source\Catel.Core\output\nl\Catel.Core.resources.dll", false)]
+        [TestCase(@"C:\Source\Catel.Core\output\runtimes\win-x64\Catel.Core.dll", false)]
+        public void IsRuntimeReference_UseNonRuntimeReferencePath(string input, bool expectedOutput)
+        {
+            var reference = new Reference(input, useRuntimeReferencePaths: false);
 
             Assert.AreEqual(expectedOutput, reference.IsRuntimeReference);
         }
@@ -40,7 +70,17 @@
         [TestCase(@"C:\Source\Catel.Core\output\runtimes\win-x64\Catel.Core.dll", false)]
         public void IsResourcesAssembly(string input, bool expectedOutput)
         {
-            var reference = new Reference(input);
+            var reference = new Reference(input, useRuntimeReferencePaths: true);
+
+            Assert.AreEqual(expectedOutput, reference.IsResourcesAssembly);
+        }
+
+        [TestCase(@"C:\Source\Catel.Core\output\Catel.Core.dll", false)]
+        [TestCase(@"C:\Source\Catel.Core\output\nl\Catel.Core.resources.dll", true)]
+        [TestCase(@"C:\Source\Catel.Core\output\runtimes\win-x64\Catel.Core.dll", false)]
+        public void IsResourcesAssembly_UseNonRuntimeReferencePath(string input, bool expectedOutput)
+        {
+            var reference = new Reference(input, useRuntimeReferencePaths: false);
 
             Assert.AreEqual(expectedOutput, reference.IsResourcesAssembly);
         }

--- a/src/Costura.Fody/Configuration.cs
+++ b/src/Costura.Fody/Configuration.cs
@@ -13,6 +13,7 @@ public class Configuration
         OptOutAssemblies = true;
         IncludeDebugSymbols = true;
         IncludeRuntimeReferences = true;
+        UseRuntimeReferencePaths = null;
         DisableCompression = false;
         DisableCleanup = false;
         LoadAtModuleInit = true;
@@ -45,6 +46,7 @@ public class Configuration
 
         IncludeDebugSymbols = ReadBool(config, "IncludeDebugSymbols", IncludeDebugSymbols);
         IncludeRuntimeReferences = ReadBool(config, "IncludeRuntimeReferences", IncludeRuntimeReferences);
+        UseRuntimeReferencePaths = ReadBool(config, "UseRuntimeReferencePaths");
         DisableCompression = ReadBool(config, "DisableCompression", DisableCompression);
         DisableCleanup = ReadBool(config, "DisableCleanup", DisableCleanup);
         LoadAtModuleInit = ReadBool(config, "LoadAtModuleInit", LoadAtModuleInit);
@@ -69,6 +71,7 @@ public class Configuration
     public bool OptOutRuntimeAssemblies { get; }
     public bool IncludeDebugSymbols { get; }
     public bool IncludeRuntimeReferences { get; }
+    public bool? UseRuntimeReferencePaths { get; }
     public bool DisableCompression { get; }
     public bool DisableCleanup { get; }
     public bool LoadAtModuleInit { get; }
@@ -84,6 +87,11 @@ public class Configuration
 
     public static bool ReadBool(XElement config, string nodeName, bool @default)
     {
+        return ReadBool(config, nodeName) ?? @default;
+    }
+
+    public static bool? ReadBool(XElement config, string nodeName)
+    {
         var attribute = config.Attribute(nodeName);
         if (attribute != null)
         {
@@ -97,7 +105,7 @@ public class Configuration
             }
         }
 
-        return @default;
+        return null;
     }
 
     public static List<string> ReadList(XElement config, string nodeName)

--- a/src/Costura.Fody/Costura.Fody.xcf
+++ b/src/Costura.Fody/Costura.Fody.xcf
@@ -52,6 +52,11 @@
       <xs:documentation>Controls if runtime assemblies are also embedded.</xs:documentation>
     </xs:annotation>
   </xs:attribute>
+  <xs:attribute name="UseRuntimeReferencePaths" type="xs:boolean">
+    <xs:annotation>
+      <xs:documentation>Controls whether the runtime assemblies are embedded with their full path or only with their assembly name.</xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
   <xs:attribute name="DisableCompression" type="xs:boolean">
     <xs:annotation>
       <xs:documentation>Embedded assemblies are compressed by default, and uncompressed when they are loaded. You can turn compression off with this option.</xs:documentation>

--- a/src/Costura.Fody/Reference.cs
+++ b/src/Costura.Fody/Reference.cs
@@ -7,7 +7,7 @@ public class Reference
 {
     // Path such as "C:\\Program Files\\dotnet\\sdk\\NuGetFallbackFolder\\runtime.win-arm64.runtime.native.system.data.sqlclient.sni\\4.4.0\\runtimes\\win-arm64\\native\\sni.dll"
 
-    public Reference(string fullPath)
+    public Reference(string fullPath, bool useRuntimeReferencePaths)
     {
         if (!Path.IsPathRooted(fullPath))
         {
@@ -21,7 +21,7 @@ public class Reference
         FileNameWithoutExtension = Path.GetFileNameWithoutExtension(fullPath);
         Directory = Path.GetDirectoryName(fullPath);
 
-        CalculateRelativeFileName();
+        CalculateRelativeFileName(useRuntimeReferencePaths);
     }
 
     public string FullPath { get; private set; }
@@ -44,7 +44,7 @@ public class Reference
 
     public string PredictedResourceName { get; private set; }
 
-    private void CalculateRelativeFileName()
+    private void CalculateRelativeFileName(bool useRuntimeReferencePaths)
     {
         const string RuntimesFolderName = "runtimes";
 
@@ -71,7 +71,7 @@ public class Reference
         }
 
         IsResourcesAssembly = relativeFileName.EndsWith("resources.dll");
-        IsRuntimeReference = directoryName.Equals(RuntimesFolderName, StringComparison.OrdinalIgnoreCase);
+        IsRuntimeReference = useRuntimeReferencePaths && directoryName.Equals(RuntimesFolderName, StringComparison.OrdinalIgnoreCase);
 
         if (IsRuntimeReference)
         {

--- a/src/Costura.Fody/ResourceEmbedder.cs
+++ b/src/Costura.Fody/ResourceEmbedder.cs
@@ -25,7 +25,9 @@ public partial class ModuleWeaver : IDisposable
         _cachePath = Path.Combine(assemblyDirectory, "Costura");
         Directory.CreateDirectory(_cachePath);
 
-        var references = GetReferences();
+        var useRuntimeReferencePaths = config.UseRuntimeReferencePaths ?? ModuleDefinition.IsUsingDotNetCore();
+
+        var references = GetReferences(useRuntimeReferencePaths);
         var embeddedReferences = new List<EmbeddedReferenceInfo>();
 
         var disableCompression = config.DisableCompression;
@@ -184,7 +186,7 @@ public partial class ModuleWeaver : IDisposable
         return matchText.Equals(assemblyName, StringComparison.OrdinalIgnoreCase);
     }
 
-    private List<Reference> GetReferences()
+    private List<Reference> GetReferences(bool useRuntimeReferencePaths)
     {
         var references = new List<Reference>();
 
@@ -196,7 +198,7 @@ public partial class ModuleWeaver : IDisposable
                 continue;
             }
 
-            var reference = new Reference(item)
+            var reference = new Reference(item, useRuntimeReferencePaths)
             {
                 IsCopyLocal = true
             };
@@ -231,7 +233,7 @@ public partial class ModuleWeaver : IDisposable
                 continue;
             }
 
-            var reference = new Reference(fileName)
+            var reference = new Reference(fileName, useRuntimeReferencePaths)
             {
                 IsCopyLocal = false
             };


### PR DESCRIPTION
This new setting controls whether the *runtime* assemblies are embedded with their full path or only with their assembly name. It defaults to `false` when the weaved assembly targets .NET Framework and `true` when the weaved assembly targets .NET Core, thus matching the Costura 4 behavior and seamlessly embedding runtime references on .NET Framework assemblies.

Fixes #678