### PR TITLE
Add a targets file that removes embedded assemblies from the publish directory

### DIFF
--- a/src/Costura.Fody/Costura.Fody.csproj
+++ b/src/Costura.Fody/Costura.Fody.csproj
@@ -56,6 +56,9 @@
     <Content Include="Costura.Fody.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Costura.Fody.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Costura.Fody.xcf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/Costura.Fody/Costura.Fody.targets
+++ b/src/Costura.Fody/Costura.Fody.targets
@@ -1,0 +1,13 @@
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup Condition="$(CosturaRemoveCopyLocalFilesToPublish) == ''">
+    <CosturaRemoveCopyLocalFilesToPublish>true</CosturaRemoveCopyLocalFilesToPublish>
+  </PropertyGroup>
+
+  <Target Name="CosturaRemoveAlreadyEmbeddedFilesFromPublish" AfterTargets="ComputeResolvedFilesToPublishList" Condition="$(CosturaRemoveCopyLocalFilesToPublish) == 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(FodyRemovedReferenceCopyLocalPaths)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Costura/Costura.csproj
+++ b/src/Costura/Costura.csproj
@@ -66,5 +66,9 @@
     <CreateItem Include="$(MSBuildThisFileDirectory)..\$(PackageId)\$(PackageId).props" AdditionalMetadata="PackagePath=build">
       <Output TaskParameter="Include" ItemName="TfmSpecificPackageFile" />
     </CreateItem>
+    
+    <CreateItem Include="$(MSBuildThisFileDirectory)..\$(PackageId)\$(PackageId).targets" AdditionalMetadata="PackagePath=build">
+      <Output TaskParameter="Include" ItemName="TfmSpecificPackageFile" />
+    </CreateItem>
   </Target>
 </Project>


### PR DESCRIPTION
If that behaviour is not desirable by consumer of Costura, it can be disabled by setting the following property in the project file:
```xml
<CosturaRemoveCopyLocalFilesToPublish>false</CosturaRemoveCopyLocalFilesToPublish>
```

This was possible thanks to https://github.com/Fody/Fody/pull/981 which has been merged and published in Fody 6.5.0.

Fixes #689