### PR TITLE
Add a dotnet tool manifest file (dotnet-tools.json)

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "cake.tool": {
+      "version": "1.1.0",
+      "commands": [
+        "dotnet-cake"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add the tool manifest file referencing the `cake.tool` package so that the `dotnet tool restore` command succeeds and `dotnet cake` is available even if it was not installed as a global tool. Without it, running `.\build.ps1 --target=BuildAndPackageLocal` would abort with this error:

> Cannot find a manifest file.
> For a list of locations searched, specify the "-d" option before the tool name.
> No tools were restored.
> Could not execute because the specified command or file was not found.
> Possible reasons for this include:
>  * You misspelled a built-in dotnet command.
>  * You intended to execute a .NET program, but dotnet-cake does not exist.
>  * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.