### PR TITLE
Use the assembly resolver from the module definition

### DIFF
--- a/src/Costura.Fody.Tests/Helpers/WeavingHelper.cs
+++ b/src/Costura.Fody.Tests/Helpers/WeavingHelper.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Xml.Linq;
 using Costura.Fody.Tests;
@@ -16,7 +15,6 @@ public static class WeavingHelper
             Config = XElement.Parse(config),
             References = string.Join(";", references.Select(r => Path.Combine(currentDirectory, r))),
             ReferenceCopyLocalPaths = references.Select(r => Path.Combine(currentDirectory, r)).ToList(),
-            AssemblyResolver = new TestAssemblyResolver()
         };
 
         if (!Path.IsPathRooted(assemblyPath))

--- a/src/Costura.Fody/AssemblyLoaderImporter.cs
+++ b/src/Costura.Fody/AssemblyLoaderImporter.cs
@@ -26,7 +26,7 @@ public partial class ModuleWeaver
     {
         var readerParameters = new ReaderParameters
         {
-            AssemblyResolver = AssemblyResolver,
+            AssemblyResolver = ModuleDefinition.AssemblyResolver,
             ReadSymbols = true,
             SymbolReaderProvider = new PdbReaderProvider(),
             SymbolStream = GetType().Assembly.GetManifestResourceStream("Costura.Template.pdb"),

--- a/src/Costura.Fody/ModuleWeaver.cs
+++ b/src/Costura.Fody/ModuleWeaver.cs
@@ -1,12 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using Fody;
-using Mono.Cecil;
 
 public partial class ModuleWeaver: BaseModuleWeaver
 {
-    public IAssemblyResolver AssemblyResolver { get; set; }
-
     public override void Execute()
     {
 //#if DEBUG


### PR DESCRIPTION
Use the IAssemblyResolver provided by the module definition itself instead of the default resolver when reading the Costura template with Cecil so that assembly references are properly resolved for .NET Framework assemblies, even when running from a .NET Core runtime (which is exactly what is happening when running the `dotnet msbuild` command).

When using the default assembly resolver, bad assembly references would be added to a weaved .NET Framework assembly, for example `System.Private.CoreLib` would be added as an assembly reference, making the weaved executable crash at startup.

Fixes #694