### PR TITLE
Use a special assembly resolver to support .NET Framework 4.7 and lower

### DIFF
--- a/src/Costura.Fody/AssemblyLoaderImporter.cs
+++ b/src/Costura.Fody/AssemblyLoaderImporter.cs
@@ -26,7 +26,7 @@ public partial class ModuleWeaver
     {
         var readerParameters = new ReaderParameters
         {
-            AssemblyResolver = ModuleDefinition.AssemblyResolver,
+            AssemblyResolver = new NetStandardAssemblyResolver(this),
             ReadSymbols = true,
             SymbolReaderProvider = new PdbReaderProvider(),
             SymbolStream = GetType().Assembly.GetManifestResourceStream("Costura.Template.pdb"),

--- a/src/Costura.Fody/Costura.Fody.csproj
+++ b/src/Costura.Fody/Costura.Fody.csproj
@@ -30,6 +30,12 @@
       <LogicalName>Costura.Template.pdb</LogicalName>
     </EmbeddedResource>
 
+    <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\Facades\netstandard.dll">
+      <Link>bin\netstandard.dll</Link>
+      <InProject>false</InProject>
+      <LogicalName>Costura.NETFramework.netstandard.dll</LogicalName>
+    </EmbeddedResource>
+
     <EmbeddedResource Include="$(MSBuildProjectDirectory)\..\Costura.Template\Common.cs">
       <Link>src\Common.cs</Link>
       <InProject>false</InProject>
@@ -66,6 +72,7 @@
 
   <ItemGroup>
     <PackageReference Include="FodyHelpers" Version="6.5.1" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net48" Version="1.0.0" PrivateAssets="all" GeneratePathProperty="true" />
     <PackageReference Update="NETStandard.Library" Version="2.0.3" />
   </ItemGroup>
 

--- a/src/Costura.Fody/NetStandardAssemblyResolver.cs
+++ b/src/Costura.Fody/NetStandardAssemblyResolver.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using Mono.Cecil;
+
+/// <summary>
+/// An assembly resolver that resolves with the <see cref="IAssemblyResolver"/> of the <see cref="ModuleDefinition"/>
+/// of the given <see cref="ModuleWeaver"/> with special handling for the <c>netstandard</c> assembly reference to
+/// support .NET Framework 4.7 and lower.
+/// </summary>
+public class NetStandardAssemblyResolver : IAssemblyResolver
+{
+    private readonly ModuleWeaver _weaver;
+    private readonly HashSet<AssemblyNameReference> _resolvedReferences;
+    private readonly Lazy<AssemblyDefinition> _netStandardAssemblyDefinition;
+
+    public NetStandardAssemblyResolver(ModuleWeaver weaver)
+    {
+        _weaver = weaver ?? throw new ArgumentNullException(nameof(weaver));
+        _weaver.WriteDebug("\tResolving assembly references");
+        _resolvedReferences = new HashSet<AssemblyNameReference>();
+        _netStandardAssemblyDefinition = new Lazy<AssemblyDefinition>(() =>
+        {
+            const string dllName = "Costura.NETFramework.netstandard.dll";
+            var assembly = GetType().Assembly;
+            var stream = assembly.GetManifestResourceStream(dllName);
+            if (stream is null)
+            {
+                throw new InvalidOperationException($"Failed to get the manifest resource stream named '{dllName}' on {assembly}");
+            }
+            return AssemblyDefinition.ReadAssembly(stream, new ReaderParameters { AssemblyResolver = this });
+        });
+    }
+
+    public void Dispose()
+    {
+    }
+
+    public AssemblyDefinition Resolve(AssemblyNameReference name)
+    {
+        var assemblyDefinition = _weaver.ModuleDefinition.AssemblyResolver.Resolve(name);
+        return Resolve(name, assemblyDefinition);
+    }
+
+    public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+    {
+        var assemblyDefinition = _weaver.ModuleDefinition.AssemblyResolver.Resolve(name, parameters);
+        return Resolve(name, assemblyDefinition);
+    }
+
+    private AssemblyDefinition Resolve(AssemblyNameReference name, AssemblyDefinition assemblyDefinition)
+    {
+        if (assemblyDefinition is not null)
+        {
+            return ResolvedReference(name, assemblyDefinition);
+        }
+        if (name.Name == "netstandard" && !_weaver.ModuleDefinition.IsUsingDotNetCore())
+        {
+            var netStandardAssemblyDefinition = _netStandardAssemblyDefinition.Value;
+            return ResolvedReference(name, netStandardAssemblyDefinition);
+        }
+        throw new AssemblyResolutionException(name);
+    }
+
+    private AssemblyDefinition ResolvedReference(AssemblyNameReference name, AssemblyDefinition assemblyDefinition)
+    {
+        var added = _resolvedReferences.Add(name);
+        if (added)
+        {
+            var toFileName = string.IsNullOrEmpty(assemblyDefinition.MainModule.FileName) ? "" : $" to {assemblyDefinition.MainModule.FileName}";
+            _weaver.WriteDebug($"\t\tResolved {name}{toFileName}");
+        }
+        return assemblyDefinition ?? throw new AssemblyResolutionException(name);
+    }
+}


### PR DESCRIPTION
The change introduced in #696 only worked for apps using Costura on a .NET Core target framework or .NET Framework 4.7.1 and later. When using Costura for a project targeting .NET Framework 4.7.0 or lower, the following exception would be thrown:
```
System.ArgumentNullException
   at Mono.Cecil.Mixin.CheckType(Object type)
   at Mono.Cecil.ModuleDefinition.ImportReference(TypeReference type, IGenericParameterProvider context)
   at Mono.Cecil.ModuleDefinition.ImportReference(TypeReference type)
   at ModuleWeaver.Resolve(TypeReference baseType)
   at ModuleWeaver.ImportAssemblyLoader(Boolean createTemporaryAssemblies)
   at ModuleWeaver.Execute()
   at InnerWeaver.ExecuteWeavers()
```

It is not clear from the exception, but it occurs because the assembly resolver can't resolve the `netstandard` assembly reference. To properly resolve the `netstandard` reference on .NET Framework versions where it's not available, we embed the one from the .NET Framework 4.8 assembly references.

Fixes #697