### PR TITLE
Fix #736: Use LoadLibraryEx for preloading unmanaged libraries

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -327,6 +327,9 @@ xmldoc_indent_size = 2
 # Test projects
 #=======================================================================================
 
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = none
+
 [src/*Tests/**/*.cs]
 # We allow usage of "var" inside tests as it reduces churn as we remove/rename types
 csharp_style_var_for_built_in_types = true:none

--- a/src/Costura.Fody.Tests/BaseCosturaTest.cs
+++ b/src/Costura.Fody.Tests/BaseCosturaTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Fody;
+﻿using Fody;
 using NUnit.Framework;
 
 [TestFixture]

--- a/src/Costura.Fody.Tests/BasicTests.TemplateHasCorrectSymbols.ForScenario.TempFileTests.net.debug.approved.txt
+++ b/src/Costura.Fody.Tests/BasicTests.TemplateHasCorrectSymbols.ForScenario.TempFileTests.net.debug.approved.txt
@@ -797,16 +797,14 @@ IL_0067:  br.s       IL_0069
 IL_0069:  ldloc.s    V_5
 IL_006b:  ret
 }
-.method private hidebysig static pinvokeimpl("kernel32.dll" unicode lasterr winapi)
-bool  SetDllDirectory(string lpPathName) cil managed preservesig
-{
-}
 .method private hidebysig static pinvokeimpl("kernel32.dll" winapi)
 uint32  SetErrorMode(uint32 uMode) cil managed preservesig
 {
 }
 .method private hidebysig static pinvokeimpl("kernel32" unicode lasterr winapi)
-native int  LoadLibrary(string dllToLoad) cil managed preservesig
+native int  LoadLibraryEx(string lpFileName,
+native int hReservedNull,
+uint32 dwFlags) cil managed preservesig
 {
 }
 .method private hidebysig static void  InternalPreloadUnmanagedLibraries(string tempBasePath,
@@ -937,63 +935,64 @@ IL_00bf:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
 IL_00c4:  nop
 IL_00c5:  endfinally
 }  // end handler
-IL_00c6:  ldarg.0
-IL_00c7:  call       bool Costura.AssemblyLoader::SetDllDirectory(string)
-IL_00cc:  pop
-IL_00cd:  ldc.i4     0x8003
-IL_00d2:  stloc.1
-IL_00d3:  ldloc.1
-IL_00d4:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
-IL_00d9:  stloc.2
-IL_00da:  nop
-IL_00db:  ldarg.1
-IL_00dc:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-IL_00e1:  stloc.s    V_12
+IL_00c6:  ldc.i4     0x8003
+IL_00cb:  stloc.1
+IL_00cc:  ldloc.1
+IL_00cd:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
+IL_00d2:  stloc.2
+IL_00d3:  nop
+IL_00d4:  ldarg.1
+IL_00d5:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+IL_00da:  stloc.s    V_12
 .try
 {
-IL_00e3:  br.s       IL_011c
-IL_00e5:  ldloc.s    V_12
-IL_00e7:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-IL_00ec:  stloc.s    V_13
-IL_00ee:  nop
-IL_00ef:  ldloc.s    V_13
-IL_00f1:  call       string Costura.AssemblyLoader::ResourceNameToPath(string)
-IL_00f6:  stloc.0
-IL_00f7:  ldloc.0
-IL_00f8:  ldstr      ".dll"
-IL_00fd:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
-IL_0102:  stloc.s    V_14
-IL_0104:  ldloc.s    V_14
-IL_0106:  brfalse.s  IL_011b
-IL_0108:  nop
-IL_0109:  ldarg.0
-IL_010a:  ldloc.0
-IL_010b:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_00dc:  br.s       IL_011b
+IL_00de:  ldloc.s    V_12
+IL_00e0:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+IL_00e5:  stloc.s    V_13
+IL_00e7:  nop
+IL_00e8:  ldloc.s    V_13
+IL_00ea:  call       string Costura.AssemblyLoader::ResourceNameToPath(string)
+IL_00ef:  stloc.0
+IL_00f0:  ldloc.0
+IL_00f1:  ldstr      ".dll"
+IL_00f6:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
+IL_00fb:  stloc.s    V_14
+IL_00fd:  ldloc.s    V_14
+IL_00ff:  brfalse.s  IL_011a
+IL_0101:  nop
+IL_0102:  ldarg.0
+IL_0103:  ldloc.0
+IL_0104:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_0110:  stloc.s    V_15
-IL_0112:  ldloc.s    V_15
-IL_0114:  call       native int Costura.AssemblyLoader::LoadLibrary(string)
-IL_0119:  pop
+IL_0109:  stloc.s    V_15
+IL_010b:  ldloc.s    V_15
+IL_010d:  ldsfld     native int [mscorlib]System.IntPtr::Zero
+IL_0112:  ldc.i4.8
+IL_0113:  call       native int Costura.AssemblyLoader::LoadLibraryEx(string,
+native int,
+uint32)
+IL_0118:  pop
+IL_0119:  nop
 IL_011a:  nop
-IL_011b:  nop
-IL_011c:  ldloc.s    V_12
-IL_011e:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-IL_0123:  brtrue.s   IL_00e5
-IL_0125:  leave.s    IL_0134
+IL_011b:  ldloc.s    V_12
+IL_011d:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+IL_0122:  brtrue.s   IL_00de
+IL_0124:  leave.s    IL_0133
 }  // end .try
 finally
 {
-IL_0127:  ldloc.s    V_12
-IL_0129:  brfalse.s  IL_0133
-IL_012b:  ldloc.s    V_12
-IL_012d:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
-IL_0132:  nop
-IL_0133:  endfinally
+IL_0126:  ldloc.s    V_12
+IL_0128:  brfalse.s  IL_0132
+IL_012a:  ldloc.s    V_12
+IL_012c:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+IL_0131:  nop
+IL_0132:  endfinally
 }  // end handler
-IL_0134:  ldloc.2
-IL_0135:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
-IL_013a:  pop
-IL_013b:  ret
+IL_0133:  ldloc.2
+IL_0134:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
+IL_0139:  pop
+IL_013a:  ret
 }
 .method private hidebysig static void  PreloadUnmanagedLibraries(string hash,
 string tempBasePath,

--- a/src/Costura.Fody.Tests/BasicTests.TemplateHasCorrectSymbols.ForScenario.TempFileTests.net.release.approved.txt
+++ b/src/Costura.Fody.Tests/BasicTests.TemplateHasCorrectSymbols.ForScenario.TempFileTests.net.release.approved.txt
@@ -606,16 +606,14 @@ IL_0058:  ret
 IL_0059:  ldloc.s    V_4
 IL_005b:  ret
 }
-.method private hidebysig static pinvokeimpl("kernel32.dll" unicode lasterr winapi)
-bool  SetDllDirectory(string lpPathName) cil managed preservesig
-{
-}
 .method private hidebysig static pinvokeimpl("kernel32.dll" winapi)
 uint32  SetErrorMode(uint32 uMode) cil managed preservesig
 {
 }
 .method private hidebysig static pinvokeimpl("kernel32" unicode lasterr winapi)
-native int  LoadLibrary(string dllToLoad) cil managed preservesig
+native int  LoadLibraryEx(string lpFileName,
+native int hReservedNull,
+uint32 dwFlags) cil managed preservesig
 {
 }
 .method private hidebysig static void  InternalPreloadUnmanagedLibraries(string tempBasePath,
@@ -716,55 +714,56 @@ IL_009d:  ldloc.3
 IL_009e:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
 IL_00a3:  endfinally
 }  // end handler
-IL_00a4:  ldarg.0
-IL_00a5:  call       bool Costura.AssemblyLoader::SetDllDirectory(string)
-IL_00aa:  pop
-IL_00ab:  ldc.i4     0x8003
-IL_00b0:  stloc.1
-IL_00b1:  ldloc.1
-IL_00b2:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
-IL_00b7:  stloc.2
-IL_00b8:  ldarg.1
-IL_00b9:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-IL_00be:  stloc.s    V_9
+IL_00a4:  ldc.i4     0x8003
+IL_00a9:  stloc.1
+IL_00aa:  ldloc.1
+IL_00ab:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
+IL_00b0:  stloc.2
+IL_00b1:  ldarg.1
+IL_00b2:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+IL_00b7:  stloc.s    V_9
 .try
 {
-IL_00c0:  br.s       IL_00f1
-IL_00c2:  ldloc.s    V_9
-IL_00c4:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-IL_00c9:  stloc.s    V_10
-IL_00cb:  ldloc.s    V_10
-IL_00cd:  call       string Costura.AssemblyLoader::ResourceNameToPath(string)
-IL_00d2:  stloc.0
-IL_00d3:  ldloc.0
-IL_00d4:  ldstr      ".dll"
-IL_00d9:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
-IL_00de:  brfalse.s  IL_00f1
-IL_00e0:  ldarg.0
-IL_00e1:  ldloc.0
-IL_00e2:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_00b9:  br.s       IL_00f0
+IL_00bb:  ldloc.s    V_9
+IL_00bd:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+IL_00c2:  stloc.s    V_10
+IL_00c4:  ldloc.s    V_10
+IL_00c6:  call       string Costura.AssemblyLoader::ResourceNameToPath(string)
+IL_00cb:  stloc.0
+IL_00cc:  ldloc.0
+IL_00cd:  ldstr      ".dll"
+IL_00d2:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
+IL_00d7:  brfalse.s  IL_00f0
+IL_00d9:  ldarg.0
+IL_00da:  ldloc.0
+IL_00db:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_00e7:  stloc.s    V_11
-IL_00e9:  ldloc.s    V_11
-IL_00eb:  call       native int Costura.AssemblyLoader::LoadLibrary(string)
-IL_00f0:  pop
-IL_00f1:  ldloc.s    V_9
-IL_00f3:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-IL_00f8:  brtrue.s   IL_00c2
-IL_00fa:  leave.s    IL_0108
+IL_00e0:  stloc.s    V_11
+IL_00e2:  ldloc.s    V_11
+IL_00e4:  ldsfld     native int [mscorlib]System.IntPtr::Zero
+IL_00e9:  ldc.i4.8
+IL_00ea:  call       native int Costura.AssemblyLoader::LoadLibraryEx(string,
+native int,
+uint32)
+IL_00ef:  pop
+IL_00f0:  ldloc.s    V_9
+IL_00f2:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+IL_00f7:  brtrue.s   IL_00bb
+IL_00f9:  leave.s    IL_0107
 }  // end .try
 finally
 {
-IL_00fc:  ldloc.s    V_9
-IL_00fe:  brfalse.s  IL_0107
-IL_0100:  ldloc.s    V_9
-IL_0102:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
-IL_0107:  endfinally
+IL_00fb:  ldloc.s    V_9
+IL_00fd:  brfalse.s  IL_0106
+IL_00ff:  ldloc.s    V_9
+IL_0101:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+IL_0106:  endfinally
 }  // end handler
-IL_0108:  ldloc.2
-IL_0109:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
-IL_010e:  pop
-IL_010f:  ret
+IL_0107:  ldloc.2
+IL_0108:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
+IL_010d:  pop
+IL_010e:  ret
 }
 .method private hidebysig static void  PreloadUnmanagedLibraries(string hash,
 string tempBasePath,

--- a/src/Costura.Fody.Tests/Costura.Fody.Tests.csproj
+++ b/src/Costura.Fody.Tests/Costura.Fody.Tests.csproj
@@ -40,6 +40,7 @@
     <ProjectReference Include="..\AssemblyToReference\AssemblyToReference.csproj" />
     <ProjectReference Include="..\AssemblyWithoutInitialize\AssemblyWithoutInitialize.csproj" />
     <ProjectReference Include="..\Costura.Fody\Costura.Fody.csproj" />
+    <ProjectReference Include="..\ExeToProcessWithMultipleNative\ExeToProcessWithMultipleNative.csproj" />
     <ProjectReference Include="..\ExeToProcessWithNativeAndEmbeddedMixed\ExeToProcessWithNativeAndEmbeddedMixed.csproj" />
     <ProjectReference Include="..\ExeToProcessWithNative\ExeToProcessWithNative.csproj" />
     <ProjectReference Include="..\ExeToProcess\ExeToProcess.csproj" />

--- a/src/Costura.Fody.Tests/MixedAndNativeTests.TemplateHasCorrectSymbols.ForScenario.MixedAndNativeTests.net.debug.approved.txt
+++ b/src/Costura.Fody.Tests/MixedAndNativeTests.TemplateHasCorrectSymbols.ForScenario.MixedAndNativeTests.net.debug.approved.txt
@@ -969,16 +969,14 @@ IL_008c:  endfinally
 IL_008d:  ldloc.s    V_8
 IL_008f:  ret
 }
-.method private hidebysig static pinvokeimpl("kernel32.dll" unicode lasterr winapi)
-bool  SetDllDirectory(string lpPathName) cil managed preservesig
-{
-}
 .method private hidebysig static pinvokeimpl("kernel32.dll" winapi)
 uint32  SetErrorMode(uint32 uMode) cil managed preservesig
 {
 }
 .method private hidebysig static pinvokeimpl("kernel32" unicode lasterr winapi)
-native int  LoadLibrary(string dllToLoad) cil managed preservesig
+native int  LoadLibraryEx(string lpFileName,
+native int hReservedNull,
+uint32 dwFlags) cil managed preservesig
 {
 }
 .method private hidebysig static void  InternalPreloadUnmanagedLibraries(string tempBasePath,
@@ -1109,63 +1107,64 @@ IL_00bf:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
 IL_00c4:  nop
 IL_00c5:  endfinally
 }  // end handler
-IL_00c6:  ldarg.0
-IL_00c7:  call       bool Costura.AssemblyLoader::SetDllDirectory(string)
-IL_00cc:  pop
-IL_00cd:  ldc.i4     0x8003
-IL_00d2:  stloc.1
-IL_00d3:  ldloc.1
-IL_00d4:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
-IL_00d9:  stloc.2
-IL_00da:  nop
-IL_00db:  ldarg.1
-IL_00dc:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
-IL_00e1:  stloc.s    V_12
+IL_00c6:  ldc.i4     0x8003
+IL_00cb:  stloc.1
+IL_00cc:  ldloc.1
+IL_00cd:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
+IL_00d2:  stloc.2
+IL_00d3:  nop
+IL_00d4:  ldarg.1
+IL_00d5:  callvirt   instance class [mscorlib]System.Collections.Generic.IEnumerator`1<!0> class [mscorlib]System.Collections.Generic.IEnumerable`1<string>::GetEnumerator()
+IL_00da:  stloc.s    V_12
 .try
 {
-IL_00e3:  br.s       IL_011c
-IL_00e5:  ldloc.s    V_12
-IL_00e7:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
-IL_00ec:  stloc.s    V_13
-IL_00ee:  nop
-IL_00ef:  ldloc.s    V_13
-IL_00f1:  call       string Costura.AssemblyLoader::ResourceNameToPath(string)
-IL_00f6:  stloc.0
-IL_00f7:  ldloc.0
-IL_00f8:  ldstr      ".dll"
-IL_00fd:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
-IL_0102:  stloc.s    V_14
-IL_0104:  ldloc.s    V_14
-IL_0106:  brfalse.s  IL_011b
-IL_0108:  nop
-IL_0109:  ldarg.0
-IL_010a:  ldloc.0
-IL_010b:  call       string [mscorlib]System.IO.Path::Combine(string,
+IL_00dc:  br.s       IL_011b
+IL_00de:  ldloc.s    V_12
+IL_00e0:  callvirt   instance !0 class [mscorlib]System.Collections.Generic.IEnumerator`1<string>::get_Current()
+IL_00e5:  stloc.s    V_13
+IL_00e7:  nop
+IL_00e8:  ldloc.s    V_13
+IL_00ea:  call       string Costura.AssemblyLoader::ResourceNameToPath(string)
+IL_00ef:  stloc.0
+IL_00f0:  ldloc.0
+IL_00f1:  ldstr      ".dll"
+IL_00f6:  callvirt   instance bool [mscorlib]System.String::EndsWith(string)
+IL_00fb:  stloc.s    V_14
+IL_00fd:  ldloc.s    V_14
+IL_00ff:  brfalse.s  IL_011a
+IL_0101:  nop
+IL_0102:  ldarg.0
+IL_0103:  ldloc.0
+IL_0104:  call       string [mscorlib]System.IO.Path::Combine(string,
 string)
-IL_0110:  stloc.s    V_15
-IL_0112:  ldloc.s    V_15
-IL_0114:  call       native int Costura.AssemblyLoader::LoadLibrary(string)
-IL_0119:  pop
+IL_0109:  stloc.s    V_15
+IL_010b:  ldloc.s    V_15
+IL_010d:  ldsfld     native int [mscorlib]System.IntPtr::Zero
+IL_0112:  ldc.i4.8
+IL_0113:  call       native int Costura.AssemblyLoader::LoadLibraryEx(string,
+native int,
+uint32)
+IL_0118:  pop
+IL_0119:  nop
 IL_011a:  nop
-IL_011b:  nop
-IL_011c:  ldloc.s    V_12
-IL_011e:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
-IL_0123:  brtrue.s   IL_00e5
-IL_0125:  leave.s    IL_0134
+IL_011b:  ldloc.s    V_12
+IL_011d:  callvirt   instance bool [mscorlib]System.Collections.IEnumerator::MoveNext()
+IL_0122:  brtrue.s   IL_00de
+IL_0124:  leave.s    IL_0133
 }  // end .try
 finally
 {
-IL_0127:  ldloc.s    V_12
-IL_0129:  brfalse.s  IL_0133
-IL_012b:  ldloc.s    V_12
-IL_012d:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
-IL_0132:  nop
-IL_0133:  endfinally
+IL_0126:  ldloc.s    V_12
+IL_0128:  brfalse.s  IL_0132
+IL_012a:  ldloc.s    V_12
+IL_012c:  callvirt   instance void [mscorlib]System.IDisposable::Dispose()
+IL_0131:  nop
+IL_0132:  endfinally
 }  // end handler
-IL_0134:  ldloc.2
-IL_0135:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
-IL_013a:  pop
-IL_013b:  ret
+IL_0133:  ldloc.2
+IL_0134:  call       uint32 Costura.AssemblyLoader::SetErrorMode(uint32)
+IL_0139:  pop
+IL_013a:  ret
 }
 .method private hidebysig static void  PreloadUnmanagedLibraries(string hash,
 string tempBasePath,

--- a/src/Costura.Fody.Tests/MixedAndNativeTests.cs
+++ b/src/Costura.Fody.Tests/MixedAndNativeTests.cs
@@ -9,7 +9,7 @@ public class MixedAndNativeTests : BaseCosturaTest
 
     private static readonly TestResult testResult = WeavingHelper.CreateIsolatedAssemblyCopy("ExeToProcessWithNative.exe",
         "<Costura Unmanaged32Assemblies='AssemblyToReferenceMixed' />",
-        new[] {"AssemblyToReferenceMixed.dll"}, "MixedAndNative");
+        new[] { "AssemblyToReferenceMixed.dll" }, "MixedAndNative");
 
     [Test]
     public void Native()

--- a/src/Costura.Fody.Tests/MultipleNativeTests.cs
+++ b/src/Costura.Fody.Tests/MultipleNativeTests.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Fody;
+using NUnit.Framework;
+
+public class MultipleNativeTests : BaseCosturaTest
+{
+    private static readonly TestResult testResult = WeavingHelper.CreateIsolatedAssemblyCopy(
+        "ExeToProcessWithMultipleNative.exe",
+        "<Costura />", 
+        Array.Empty<string>(), 
+        "MultipleNative");
+
+    public override TestResult TestResult => testResult;
+
+    [Test]
+    public void Native()
+    {
+        var instance1 = TestResult.GetInstance("ExeToProcessWithMultipleNative.Program");
+        Assert.AreEqual(42, instance1.Test());
+    }
+}

--- a/src/Costura.Fody.Tests/MultipleNativeTestsWithPreloadOrder.cs
+++ b/src/Costura.Fody.Tests/MultipleNativeTestsWithPreloadOrder.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Fody;
+using NUnit.Framework;
+
+public class MultipleNativeTestsWithPreloadOrder : BaseCosturaTest
+{
+    private static readonly TestResult testResult = WeavingHelper.CreateIsolatedAssemblyCopy(
+        "ExeToProcessWithMultipleNative.exe",
+        "<Costura PreloadOrder=\"msvcr120|msvcp120|zlib|libzstd|librdkafka|librdkafkacpp\" />", 
+        Array.Empty<string>(), 
+        "MultipleNativeWithPreloadOrder");
+
+    public override TestResult TestResult => testResult;
+
+    [Test]
+    public void Native()
+    {
+        var instance1 = TestResult.GetInstance("ExeToProcessWithMultipleNative.Program");
+        Assert.AreEqual(42, instance1.Test());
+    }
+}

--- a/src/Costura.Fody.sln
+++ b/src/Costura.Fody.sln
@@ -32,8 +32,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyWithoutInitialize",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "misc", "misc", "{BD2A89FD-65C5-4DC9-B50F-049CA337FF20}"
 	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
 		.vsconfig = .vsconfig
-		Costura.sln.DotSettings = Costura.sln.DotSettings
+		Costura.Fody.sln.DotSettings = Costura.Fody.sln.DotSettings
 		Directory.build.analyzers.props = Directory.build.analyzers.props
 		Directory.build.project.props = Directory.build.project.props
 		Directory.Build.props = Directory.Build.props
@@ -63,6 +64,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExeToProcessWithNativeAndEmbeddedMixed", "ExeToProcessWithNativeAndEmbeddedMixed\ExeToProcessWithNativeAndEmbeddedMixed.csproj", "{1BACB257-5B8A-45D4-BC49-51985E076BD2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AssemblyToReferenceWithRuntimeReferences", "AssemblyToReferenceWithRuntimeReferences\AssemblyToReferenceWithRuntimeReferences.csproj", "{3C8562E5-DAEE-410D-A492-1EAC53ED4290}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExeToProcessWithMultipleNative", "ExeToProcessWithMultipleNative\ExeToProcessWithMultipleNative.csproj", "{24395ED7-04CF-45E4-AB58-D6AA4F340335}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -266,6 +269,18 @@ Global
 		{3C8562E5-DAEE-410D-A492-1EAC53ED4290}.Release|x64.Build.0 = Release|Any CPU
 		{3C8562E5-DAEE-410D-A492-1EAC53ED4290}.Release|x86.ActiveCfg = Release|Any CPU
 		{3C8562E5-DAEE-410D-A492-1EAC53ED4290}.Release|x86.Build.0 = Release|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Debug|x64.Build.0 = Debug|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Debug|x86.Build.0 = Debug|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Release|Any CPU.Build.0 = Release|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Release|x64.ActiveCfg = Release|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Release|x64.Build.0 = Release|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Release|x86.ActiveCfg = Release|Any CPU
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -290,6 +305,7 @@ Global
 		{2B508691-68E6-4AE6-8F8D-1B78F7E65F80} = {B7B46C59-9452-424E-ABFE-1350A00D0FD4}
 		{1BACB257-5B8A-45D4-BC49-51985E076BD2} = {93B6F5A2-F07C-4DB0-B65F-02F69B9DC6B2}
 		{3C8562E5-DAEE-410D-A492-1EAC53ED4290} = {93B6F5A2-F07C-4DB0-B65F-02F69B9DC6B2}
+		{24395ED7-04CF-45E4-AB58-D6AA4F340335} = {93B6F5A2-F07C-4DB0-B65F-02F69B9DC6B2}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {2231BA74-85F3-48B2-9340-B98CDF1C5031}

--- a/src/Costura.Fody/AssemblyLoaderImporter.cs
+++ b/src/Costura.Fody/AssemblyLoaderImporter.cs
@@ -306,7 +306,8 @@ public partial class ModuleWeaver
 
         if (operand is FieldReference fieldReference)
         {
-            return _targetType.Fields.FirstOrDefault(f => f.Name == fieldReference.Name);
+            return _targetType.Fields.FirstOrDefault(f => f.Name == fieldReference.Name) 
+                   ?? new FieldReference(fieldReference.Name, ModuleDefinition.ImportReference(fieldReference.FieldType.Resolve()), ModuleDefinition.ImportReference(fieldReference.DeclaringType.Resolve()));
         }
         return operand;
     }

--- a/src/Costura.Fody/ResourceEmbedder.cs
+++ b/src/Costura.Fody/ResourceEmbedder.cs
@@ -212,7 +212,7 @@ public partial class ModuleWeaver : IDisposable
         }
 
         // Add all references, but mark them as special
-        var splittedReferences = References.Split(';');
+        var splittedReferences = References.Split(';').Where(item => !string.IsNullOrEmpty(item));
 
         foreach (var splittedReference in splittedReferences)
         {

--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -14,11 +14,7 @@ using System.Threading;
 internal static class Common
 {
     [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
-    static extern IntPtr LoadLibrary(string dllToLoad);
-
-    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    static extern bool SetDllDirectory(string lpPathName);
+    public static extern IntPtr LoadLibraryEx(string lpFileName, IntPtr hReservedNull, uint dwFlags);
 
     [Conditional("DEBUG")]
     public static void Log(string format, params object[] args)
@@ -255,8 +251,6 @@ internal static class Common
             }
         }
 
-        SetDllDirectory(tempBasePath);
-
         // prevent system-generated error message when LoadLibrary is called on a dll with an unmet dependency
         // https://msdn.microsoft.com/en-us/library/windows/desktop/ms680621(v=vs.85).aspx
         //
@@ -277,7 +271,8 @@ internal static class Common
             {
                 var assemblyTempFilePath = Path.Combine(tempBasePath, name);
 
-                LoadLibrary(assemblyTempFilePath);
+                // LOAD_WITH_ALTERED_SEARCH_PATH = 0x00000008
+                LoadLibraryEx(assemblyTempFilePath, IntPtr.Zero, 0x00000008);
             }
         }
 

--- a/src/ExeToProcessWithMultipleNative/ExeToProcessWithMultipleNative.csproj
+++ b/src/ExeToProcessWithMultipleNative/ExeToProcessWithMultipleNative.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net472</TargetFramework>
+    <DebugType>embedded</DebugType>
+    <AutoGenerateBindingRedirects>false</AutoGenerateBindingRedirects>
+    <GenerateSupportedRuntime>false</GenerateSupportedRuntime>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DisableFody>true</DisableFody>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="1.7.0" />
+  </ItemGroup>
+
+  <Target Name="EmbedLibrdkafkaRedistNativeLibraries" BeforeTargets="ResolvePackageAssets">
+    <ItemGroup>
+      <LibrdkafkaNativeLibraries Include="@(Content)" Condition="$([MSBuild]::ValueOrDefault('%(Link)', '').StartsWith('librdkafka'))" />
+      <LibrdkafkaNativeLibraries Update="@(LibrdkafkaNativeLibraries)" CopyToOutputDirectory="Never" />
+      <Content Remove="@(LibrdkafkaNativeLibraries)" />
+    </ItemGroup>
+    <ItemGroup>
+      <EmbeddedResource Include="@(LibrdkafkaNativeLibraries)">
+        <Link Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').Contains('x86'))">costura32\%(Filename)%(Extension)</Link>
+        <Link Condition="$([MSBuild]::ValueOrDefault('%(Identity)', '').Contains('x64'))">costura64\%(Filename)%(Extension)</Link>
+      </EmbeddedResource>
+    </ItemGroup>
+  </Target>
+
+  <Import Project="$(MSBuildProjectDirectory)\..\Directory.build.shared.explicit.props" Condition="Exists('$(MSBuildProjectDirectory)\..\Directory.build.shared.explicit.props')" />
+
+</Project>

--- a/src/ExeToProcessWithMultipleNative/Program.cs
+++ b/src/ExeToProcessWithMultipleNative/Program.cs
@@ -1,0 +1,25 @@
+﻿namespace ExeToProcessWithMultipleNative
+{
+    using System;
+
+    public class Program
+    {
+        public static int Main()
+        {
+            // you can pass ANY valid library here, it's only important that kafka runs it's internal setup :-)
+            Confluent.Kafka.Library.Load("librdkafka.dll");
+
+            QueueHelper.SendMessage("test", "message1");
+
+            Console.WriteLine(Guid.NewGuid().ToString());
+            QueueHelper.SendMessage("test", "message2");
+
+            return 42;
+        }
+
+        public int Test()
+        {
+            return Main();
+        }
+    }
+}

--- a/src/ExeToProcessWithMultipleNative/QueueHelper.cs
+++ b/src/ExeToProcessWithMultipleNative/QueueHelper.cs
@@ -1,0 +1,21 @@
+﻿namespace ExeToProcessWithMultipleNative
+{
+    using System.Net;
+
+    using Confluent.Kafka;
+
+    public static class QueueHelper
+    {
+        private const string QueueAddressesList = "kafka:9200";
+
+        public static void SendMessage(string topic, string message)
+        {
+            var producer = new ProducerBuilder<Null, string>(new ProducerConfig
+            {
+                ClientId = Dns.GetHostName(),
+                BootstrapServers = QueueAddressesList
+            }).Build();
+            producer.Produce(topic, new Message<Null, string> { Value = message });
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###

Use LoadLibraryEx for preloading unmanaged libraries

### Issues Resolved ### 

- fixes #736

### API Changes ###
 
None

### Platforms Affected ### 

- All

### Behavioral Changes ###

None

### Testing Procedure ###

run the new unit tests "MultipleNativeTests*" 

### PR Checklist ###

- [x ] I have included examples or tests
- [ ] I have updated the change log => ??? did not find this
- [ ] I am listed in the CONTRIBUTORS file => ??? did not find this
- [x ] Rebased on top of the target branch at time of PR
- [x ] Changes adhere to coding standard
