### PR TITLE
fix #738

### DIFF
--- a/src/Costura.Fody.IntegrationTests/Costura.Fody.IntegrationTests.csproj
+++ b/src/Costura.Fody.IntegrationTests/Costura.Fody.IntegrationTests.csproj
@@ -19,6 +19,10 @@
     <PackageReference Include="NUnit" Version="3.13.2" PrivateAssets="all" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Costura\Costura.csproj" />
+  </ItemGroup>
 
   <ItemGroup>
     <WeaverFiles Include="$(OverridableOutputRootPath)\Costura.Fody\netstandard2.0\Costura.Fody.dll" />

--- a/src/Costura.Fody.IntegrationTests/FodyWeavers.xml
+++ b/src/Costura.Fody.IntegrationTests/FodyWeavers.xml
@@ -1,3 +1,3 @@
 ﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura IncludeAssemblies="Catel.Core" DisableCleanup="false" />
+  <Costura IncludeAssemblies="Catel.Core" DisableCleanup="false" LoadAtModuleInit="false" />
 </Weavers>

--- a/src/Costura.Fody.IntegrationTests/Integration.cs
+++ b/src/Costura.Fody.IntegrationTests/Integration.cs
@@ -6,6 +6,11 @@ using NUnit.Framework;
 [TestFixture]
 public class Integration
 {
+    static Integration()
+    {
+        CosturaUtility.Initialize();
+    }
+
     [Test, Explicit]
     public void Test()
     {

--- a/src/Costura.Fody/AssemblyLoaderImporter.cs
+++ b/src/Costura.Fody/AssemblyLoaderImporter.cs
@@ -28,8 +28,7 @@ public partial class ModuleWeaver
         {
             AssemblyResolver = new NetStandardAssemblyResolver(this),
             ReadSymbols = true,
-            SymbolReaderProvider = new PdbReaderProvider(),
-            SymbolStream = GetType().Assembly.GetManifestResourceStream("Costura.Template.pdb"),
+            SymbolReaderProvider = new PdbReaderProvider()
         };
 
         using (var resourceStream = GetType().Assembly.GetManifestResourceStream("Costura.Template.dll"))

--- a/src/Costura.Fody/Costura.Fody.csproj
+++ b/src/Costura.Fody/Costura.Fody.csproj
@@ -24,12 +24,6 @@
       <LogicalName>Costura.Template.dll</LogicalName>
     </EmbeddedResource>
 
-    <EmbeddedResource Include="$(OverridableOutputRootPath)\Costura.Template\netstandard2.0\Costura.Template.pdb">
-      <Link>bin\Template.pdb</Link>
-      <InProject>false</InProject>
-      <LogicalName>Costura.Template.pdb</LogicalName>
-    </EmbeddedResource>
-
     <EmbeddedResource Include="$(PkgMicrosoft_NETFramework_ReferenceAssemblies_net48)\build\.NETFramework\v4.8\Facades\netstandard.dll">
       <Link>bin\netstandard.dll</Link>
       <InProject>false</InProject>

--- a/src/Costura.Template/Costura.Template.csproj
+++ b/src/Costura.Template/Costura.Template.csproj
@@ -8,13 +8,15 @@
     <Description></Description>
     <PackageTags></PackageTags>
     <DisableFody>true</DisableFody>
+    <DebugType>embedded</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup>
     <!-- SonarQube requires a project guid -->
     <ProjectGuid>{CD9AEBAA-78F4-4A78-BF06-0CB7D84D83E8}</ProjectGuid>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Fody" Version="6.5.2" PrivateAssets="none" />
   </ItemGroup>

--- a/src/Directory.Build.shared.explicit.props
+++ b/src/Directory.Build.shared.explicit.props
@@ -43,7 +43,7 @@
         <Message Importance="High" Text="Target platform identifier is '$(TargetPlatformIdentifier)', applying pdb fix" />
       </Target>-->
       <ItemGroup>
-        <PackageReference Include="SourceLink.Copy.PdbFiles" Version="2.8.3" PrivateAssets="All" />
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
       </ItemGroup>
     </When>
     <Otherwise>


### PR DESCRIPTION
### Description of Change ###

Fix handling of debug information/sequence points in AssemblyLoaderImporter.cs

### Issues Resolved ### 

- fixes  #738

### API Changes ###
 
None

### Platforms Affected ### 

- All

### Behavioral Changes ###

None

### Testing Procedure ###

- Put a breakpoint at  the "Integration" test static constructor
- Debug the test
- Step into the `CosturaUtility.Initialize()` method

TODO: not sure how that complies with the outdated version of SourceLink, maybe that needs to be updated?

### PR Checklist ###

- [x] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
