### PR TITLE
Fix compilation of the test project (Costura.Fody.Tests)

### DIFF
--- a/src/Costura.Fody.Tests/Costura.Fody.Tests.csproj
+++ b/src/Costura.Fody.Tests/Costura.Fody.Tests.csproj
@@ -21,13 +21,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NUnit" Version="3.13.2" PrivateAssets="all" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="WpfAnalyzers" Version="3.5.0" PrivateAssets="all">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>    


### PR DESCRIPTION
When compiling with Rider, I get the following error:
> Costura.Fody.Tests.csproj: [NU1601] Dependency specified was WpfAnalyzers (>= 3.5.0) but ended up with WpfAnalyzers 3.5.4.

The `WpfAnalyzers` package is already included through `Directory.Build.analyzers.props` so we can safely remove it.