### PR TITLE
Explicitly compile 32-bits projects with PlatformTarget=x86

### DIFF
--- a/src/ExeToProcessWithNative/ExeToProcessWithNative.csproj
+++ b/src/ExeToProcessWithNative/ExeToProcessWithNative.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <DisableFody>true</DisableFody>
     <OutputType>Exe</OutputType>
+    <PlatformTarget>x86</PlatformTarget>
     <NoWarn>$(NoWarn);NU1201</NoWarn>
     <NoError>$(NoError);NU1201</NoError>
   </PropertyGroup>

--- a/src/ExeToProcessWithNativeAndEmbeddedMixed/ExeToProcessWithNativeAndEmbeddedMixed.csproj
+++ b/src/ExeToProcessWithNativeAndEmbeddedMixed/ExeToProcessWithNativeAndEmbeddedMixed.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
     <DisableFody>true</DisableFody>
     <OutputType>Exe</OutputType>
+    <PlatformTarget>x86</PlatformTarget>
     <NoWarn>$(NoWarn);NU1201</NoWarn>
     <NoError>$(NoError);NU1201</NoError>
   </PropertyGroup>


### PR DESCRIPTION
AssemblyToReferenceNative.dll and AssemblyToReferenceMixed.dll are embedded as 32-bits dlls (in the costura32 directory) so using PlatformTarget=x86 ensures that the executable is executed as 32-bits instead of 64-bits.

Without this the following tests would fail.

MixedAndNativeTests.Mixed and MixedAndNativeTestsWithEmbeddedMixed.Mixed with
```
System.BadImageFormatException : Could not load file or assembly 'AssemblyToReferenceMixed, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null' or one of its dependencies. An attempt was made to load a program with an incorrect format.
   at ClassToTest.MixedFoo()
```

MixedAndNativeTests.MixedPInvoke and MixedAndNativeTestsWithEmbeddedMixed.MixedPInvoke with
```
System.BadImageFormatException : An attempt was made to load a program with an incorrect format. (Exception from HRESULT: 0x8007000B)
   at ClassToTest.SayHelloFromMixed()
```

MixedAndNativeTests.Native and MixedAndNativeTestsWithEmbeddedMixed.Native with
```
System.DllNotFoundException : Unable to load DLL 'AssemblyToReferenceNative.dll': The specified module could not be found. (Exception from HRESULT: 0x8007007E)
   at ClassToTest.SayHelloFromNative()
```