### PR TITLE
Fix compression bug by removing unnecessary Flush() call

### DIFF
--- a/src/Costura.Fody/ResourceEmbedder.cs
+++ b/src/Costura.Fody/ResourceEmbedder.cs
@@ -608,7 +608,6 @@ disableCleanup: {disableCleanup}");
                         using (var compressedStream = new DeflateStream(memoryStream, CompressionMode.Compress, true))
                         {
                             fileStream.CopyTo(compressedStream);
-                            compressedStream.Flush();
                         }
                     }
                     else


### PR DESCRIPTION
The Flush() call on DeflateStream doesn't guarantee complete compression and can cause embedded DLLs to fail until project rebuild. Removing it ensures proper compression on first build.

### Description of Change ###

Fix compression bug by removing unnecessary Flush() call

### Issues Resolved ### 

<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #1050

### API Changes ###

None
 
None

### Behavioral Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###

I couldn't even figure out how to run the tests because I didn't have the MSBuild SDK but the issue was so small that I don't believe tests are needed (or you can run them as well).

### PR Checklist ###

- [X] I have included examples or tests
- [X] I have updated the change log or created a GitHub ticket with the change
- [ ] I am listed in the CONTRIBUTORS file (if it exists)
- [X] Changes adhere to coding standard
- [X] I checked the licenses of Third Party software and discussed new dependencies with at least 1 other team member