### PR TITLE
Update `ReadExistingAssembly` to ignore assembly in other `AssemblyLoadContext`

### DIFF
--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -84,7 +84,18 @@ internal static class Common
                 string.Equals(CultureToString(currentName.CultureInfo), CultureToString(name.CultureInfo), StringComparison.InvariantCultureIgnoreCase))
             {
                 Log("Assembly '{0}' already loaded, returning existing assembly", assembly.FullName);
+#if NETCORE
+                var assemblyContext = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(assembly);
+                var isIndividualAssemblyLoadContext = "System.Runtime.Loader.IndividualAssemblyLoadContext" == assemblyContext.GetType().FullName;
+                var isDefaultContext = assemblyContext == System.Runtime.Loader.AssemblyLoadContext.Default;
+                if (!isDefaultContext && !isIndividualAssemblyLoadContext)
+                {
+                    Log("Assembly Context is not valid '{0}'", assemblyContext);
+                    continue;
+                }
 
+                Log("Assembly Context is valid '{0}'", assemblyContext);
+#endif
                 return assembly;
             }
         }

--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -86,7 +86,7 @@ internal static class Common
 #if NETCORE
                 var assemblyLoadContext = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(assembly);
                 var isIndividualAssemblyLoadContext = "System.Runtime.Loader.IndividualAssemblyLoadContext" == assemblyLoadContext.GetType().FullName;
-                var isDefaultAssemblyLoadContext = assemblyContext == System.Runtime.Loader.AssemblyLoadContext.Default;
+                var isDefaultAssemblyLoadContext = assemblyLoadContext == System.Runtime.Loader.AssemblyLoadContext.Default;
                 if (!isDefaultAssemblyLoadContext && !isIndividualAssemblyLoadContext)
                 {
                     Log("Assembly Context is not valid '{0}'", assemblyContext);

--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -89,7 +89,7 @@ internal static class Common
                 var isDefaultAssemblyLoadContext = assemblyLoadContext == System.Runtime.Loader.AssemblyLoadContext.Default;
                 if (!isDefaultAssemblyLoadContext && !isIndividualAssemblyLoadContext)
                 {
-                    Log("Assembly Context is not valid '{0}'", assemblyContext);
+                    Log("Assembly Context is not valid '{0}'", assemblyLoadContext);
                     continue;
                 }
 #endif

--- a/src/Costura.Template/Common.cs
+++ b/src/Costura.Template/Common.cs
@@ -83,19 +83,19 @@ internal static class Common
             if (string.Equals(currentName.Name, name.Name, StringComparison.InvariantCultureIgnoreCase) &&
                 string.Equals(CultureToString(currentName.CultureInfo), CultureToString(name.CultureInfo), StringComparison.InvariantCultureIgnoreCase))
             {
-                Log("Assembly '{0}' already loaded, returning existing assembly", assembly.FullName);
 #if NETCORE
-                var assemblyContext = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(assembly);
-                var isIndividualAssemblyLoadContext = "System.Runtime.Loader.IndividualAssemblyLoadContext" == assemblyContext.GetType().FullName;
-                var isDefaultContext = assemblyContext == System.Runtime.Loader.AssemblyLoadContext.Default;
-                if (!isDefaultContext && !isIndividualAssemblyLoadContext)
+                var assemblyLoadContext = System.Runtime.Loader.AssemblyLoadContext.GetLoadContext(assembly);
+                var isIndividualAssemblyLoadContext = "System.Runtime.Loader.IndividualAssemblyLoadContext" == assemblyLoadContext.GetType().FullName;
+                var isDefaultAssemblyLoadContext = assemblyContext == System.Runtime.Loader.AssemblyLoadContext.Default;
+                if (!isDefaultAssemblyLoadContext && !isIndividualAssemblyLoadContext)
                 {
                     Log("Assembly Context is not valid '{0}'", assemblyContext);
                     continue;
                 }
-
-                Log("Assembly Context is valid '{0}'", assemblyContext);
 #endif
+
+                Log("Assembly '{0}' already loaded, returning existing assembly", assembly.FullName);
+                
                 return assembly;
             }
         }


### PR DESCRIPTION
### Description of Change ###

The `ReadExistingAssembly` method was updated to ignore assembly when is not in the default`AssemblyLoadContext` and not `IndividualAssemblyLoadContext`.

### Issues Resolved ### 

This PR is related to the issue: #1119 

### API Changes ###

None

### Behavioral Changes ###

None

### Testing Procedure ###

The [CosturaContextIssue.App](https://github.com/ricaun/CosturaContextIssue.App) project is a test project with the issue.
By changing the `SampleCostura` configuration using a local `Costura.Fody` version is possible to test.

Replace the `PackageReference` with the local `WeaverFiles `.

```xml
<!-- Remove this PackageReference -->
<PackageReference Include="Costura.Fody" Version="*" IncludeAssets="compile; build" PrivateAssets="all" />
```

```xml
<!-- Replace with your Costura.Fody.dll local file -->
<PackageReference Include="Fody" Version="*" IncludeAssets="compile; build" PrivateAssets="all" />
<WeaverFiles Include=".\Costura\output\Debug\Costura.Fody\netstandard2.0\Costura.Fody.dll" />
```

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log or created a GitHub ticket with the change
- [ ] I am listed in the CONTRIBUTORS file (if it exists)
- [ ] Changes adhere to coding standard
- [ ] I checked the licenses of Third Party software and discussed new dependencies with at least 1 other team member